### PR TITLE
Adding the Pack command to Extension project type.

### DIFF
--- a/lib/project_types/extension/cli.rb
+++ b/lib/project_types/extension/cli.rb
@@ -2,10 +2,16 @@
 module Extension
   class Project < ShopifyCli::ProjectType
     creator 'App Extension', 'Extension::Commands::Create'
+
+    register_command('Extension::Commands::Pack', "pack")
   end
 
   module Commands
     autoload :Create, Project.project_filepath('commands/create')
+    autoload :Pack, Project.project_filepath('commands/pack')
+  end
+
+  module Tasks
   end
 
   module Forms

--- a/lib/project_types/extension/commands/create.rb
+++ b/lib/project_types/extension/commands/create.rb
@@ -13,7 +13,7 @@ module Extension
         form = Forms::Create.ask(@ctx, args, options.flags)
         return @ctx.puts(self.class.help) if form.nil?
         build(form.title, @ctx)
-        write_envfile(form)
+        write_cli_files(form)
       end
 
       def self.help
@@ -40,7 +40,9 @@ module Extension
         JsDeps.install(ctx)
       end
 
-      def write_envfile(form)
+      def write_cli_files(form)
+        ShopifyCli::Project.write(@ctx, 'extension')
+
         ShopifyCli::Helpers::EnvFile.new(
           api_key: form.app["apiKey"],
           secret: form.app["apiSecretKeys"].first["secret"]

--- a/lib/project_types/extension/commands/pack.rb
+++ b/lib/project_types/extension/commands/pack.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+require 'shopify_cli'
+
+module Extension
+  module Commands
+    class Pack < ShopifyCli::Command
+      YARN_BUILD_COMMAND = %w(yarn build)
+      NPM_BUILD_COMMAND = %w(npm run-script build)
+
+      BUILD_FAILURE_MESSAGE = 'Failed to pack extension code for deployment.'
+
+      def call(args, command_name)
+        CLI::UI::Frame.open(frame_title) do
+          @ctx.abort(BUILD_FAILURE_MESSAGE) unless build.success?
+        end
+      end
+
+      def self.help
+        <<~HELP
+          Pack your extension to prepare for deployment.
+            Usage: {{command:#{ShopifyCli::TOOL_NAME} pack}}
+        HELP
+      end
+
+      private
+
+      def frame_title
+        "Packing extension with: #{yarn_available? ? 'yarn' : 'npm'}..."
+      end
+
+      def yarn_available?
+        @yarn_availability ||= JsDeps.new(ctx: @ctx).yarn?
+      end
+
+      def build
+        build_command = yarn_available? ? YARN_BUILD_COMMAND : NPM_BUILD_COMMAND
+        @ctx.system(*build_command)
+      end
+    end
+  end
+end

--- a/test/project_types/extension/commands/pack_test.rb
+++ b/test/project_types/extension/commands/pack_test.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+require 'test_helper'
+require 'project_types/extension/stubs'
+
+module Extension
+  module Commands
+    class PackTest < MiniTest::Test
+      include TestHelpers::Partners
+      include TestHelpers::FakeUI
+      include Extension::Stubs
+
+      class FakeProcessStatus
+        def initialize(success)
+          @success = success
+        end
+
+        def success?
+          @success
+        end
+      end
+
+      def setup
+        super
+        ShopifyCli::ProjectType.load_type(:extension)
+      end
+
+      def test_prints_help
+        @context.expects(:puts).with(Extension::Commands::Pack.help)
+        run_cmd('help pack')
+      end
+
+      def test_uses_yarn_when_yarn_is_available
+        Pack.any_instance.stubs(:yarn_available?).returns(true)
+        @context.expects(:system).with(*Pack::YARN_BUILD_COMMAND).returns(FakeProcessStatus.new(true))
+
+        run_cmd('pack')
+      end
+
+      def test_uses_npm_when_yarn_is_unavailable
+        Pack.any_instance.stubs(:yarn_available?).returns(false)
+        @context.expects(:system).with(*Pack::NPM_BUILD_COMMAND).returns(FakeProcessStatus.new(true))
+
+        run_cmd('pack')
+      end
+
+      def test_aborts_and_informs_the_user_when_build_fails
+        Pack.any_instance.stubs(:yarn_available?).returns(true)
+        @context.expects(:system).with(*Pack::YARN_BUILD_COMMAND).returns(FakeProcessStatus.new(false))
+        @context.expects(:abort).with(Pack::BUILD_FAILURE_MESSAGE)
+
+        run_cmd('pack')
+      end
+    end
+  end
+end


### PR DESCRIPTION
### WHY are these changes introduced?
Merge only after: https://github.com/Shopify/shopify-app-cli-extensions/pull/11

Closes https://github.com/Shopify/app-extension-libs/issues/288
Adds the `Pack` command to the CLI which will be necessary for Argo extensions to prepare their project for deployment.

### WHAT is this pull request doing?
Adds the `Pack` command.
Works with both NPM and YARN.