### PR TITLE
Adding the concept of extension types to the extension project type

### DIFF
--- a/lib/project_types/extension/cli.rb
+++ b/lib/project_types/extension/cli.rb
@@ -25,6 +25,11 @@ module Extension
   module Models
     autoload :Registration, Project.project_filepath('models/registration')
     autoload :Version, Project.project_filepath('models/version')
+    autoload :Type, Project.project_filepath('models/type')
+
+    class << self
+      Models::Type.load_all
+    end
   end
 
   autoload :JsDeps, Project.project_filepath('js_deps')

--- a/lib/project_types/extension/commands/create.rb
+++ b/lib/project_types/extension/commands/create.rb
@@ -5,7 +5,7 @@ module Extension
     class Create < ShopifyCli::SubCommand
       options do |parser, flags|
         parser.on('--title=TITLE') { |title| flags[:title] = title }
-        parser.on('--type=TYPE') { |type| flags[:type] = type.downcase  }
+        parser.on('--type=TYPE') { |type| flags[:type] = type.upcase  }
         parser.on('--api-key=KEY') { |key| flags[:api_key] = key.downcase }
       end
 

--- a/lib/project_types/extension/commands/deploy.rb
+++ b/lib/project_types/extension/commands/deploy.rb
@@ -24,9 +24,7 @@ module Extension
           context: @ctx,
           api_key: @project.env['api_key'],
           registration_id: @project.registration_id,
-          config: {
-            serialized_script: encode_script
-          }
+          config: @project.extension_type.config(@ctx)
         )
       end
 
@@ -34,11 +32,9 @@ module Extension
         registration = Tasks::CreateExtension.call(
           context: @ctx,
           api_key: @project.env['api_key'],
-          type: @project.extension_type,
+          type: @project.extension_type.identifier,
           title: 'Testing the CLI',
-          config: {
-            serialized_script: encode_script
-          }
+          config: @project.extension_type.config(@ctx)
         )
 
         @project.set_registration_id(@ctx, registration.id)

--- a/lib/project_types/extension/extension_project.rb
+++ b/lib/project_types/extension/extension_project.rb
@@ -45,7 +45,7 @@ module Extension
     end
 
     def extension_type
-      env[:extra][EXTENSION_TYPE_KEY]
+      Models::Type.load_type(env[:extra][EXTENSION_TYPE_KEY])
     end
   end
 end

--- a/lib/project_types/extension/forms/create.rb
+++ b/lib/project_types/extension/forms/create.rb
@@ -7,22 +7,6 @@ module Extension
 
       attr_reader :app
 
-      ExtensionType = Struct.new(:identifier, :description, keyword_init: true) do
-        def ==(extensionType)
-          case extensionType
-          when String
-            self.identifier == extensionType
-          else
-            super(extensionType)
-          end
-        end
-      end
-
-      EXTENSION_TYPES = [
-        ExtensionType.new(identifier: 'product-details', description: 'Product extension'),
-        ExtensionType.new(identifier: 'customer-details', description: 'Customer extension')
-      ]
-
       def ask
         self.title = ask_title
         self.type = ask_type
@@ -41,11 +25,12 @@ module Extension
       end
 
       def ask_type
-        return type if EXTENSION_TYPES.include?(type)
+        return type if Models::Type.valid?(type)
         raise(ShopifyCli::Abort, 'Invalid extension type.') unless type.nil?
+
         CLI::UI::Prompt.ask('What type of extension would you like to create?') do |handler|
-          EXTENSION_TYPES.each do |type|
-            handler.option(type.description) { type.identifier }
+          Models::Type.repository.values.each do |type|
+            handler.option(type.name) { type.identifier }
           end
         end
       end

--- a/lib/project_types/extension/models/type.rb
+++ b/lib/project_types/extension/models/type.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module Extension
+  module Models
+    class Type
+      TYPES_PATH = %w(lib project_types extension models types *.rb)
+
+      class << self
+        def load_all
+          return unless @all_extension_types.nil? || @all_extension_types.empty?
+          Dir.glob(File.join(ShopifyCli::ROOT, TYPES_PATH)).map { |file_path| load(file_path) }
+        end
+
+        def inherited(klass)
+          @all_extension_types ||= []
+          @all_extension_types << klass
+        end
+
+        def valid?(identifier)
+          repository.key?(identifier)
+        end
+
+        def repository
+          load_all if @all_extension_types.empty?
+
+          @repository ||= @all_extension_types.map(&:new).each_with_object({}) do |type, hash|
+            hash[type.identifier] = type
+          end
+        end
+
+        def load_type(identifier)
+          repository[identifier]
+        end
+      end
+
+      def identifier
+        raise NotImplementedError, "'#{__method__}' must be implemented for #{self.class}"
+      end
+
+      def name
+        raise NotImplementedError, "'#{__method__}' must be implemented for #{self.class}"
+      end
+
+      def config(_context)
+        raise NotImplementedError, "'#{__method__}' must be implemented for #{self.class}"
+      end
+
+      def extension_context(_context)
+        nil
+      end
+
+      def valid_extension_contexts
+        []
+      end
+    end
+  end
+end

--- a/lib/project_types/extension/models/types/shopify_hosted_app_link.rb
+++ b/lib/project_types/extension/models/types/shopify_hosted_app_link.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Extension
+  module Models
+    module Types
+      class ShopifyHostedAppLink < Models::Type
+        def identifier
+          'SHOPIFY_HOSTED_APP_LINK'
+        end
+
+        def name
+          'Shopify Hosted App Link'
+        end
+
+        def config(_context)
+          {
+            text: 'Test Based Text',
+            url: 'https://www.test-onlh.com'
+          }
+        end
+
+        def extension_context(_context)
+          valid_extension_contexts.first
+        end
+
+        def valid_extension_contexts
+          ['products#show']
+        end
+      end
+    end
+  end
+end

--- a/lib/project_types/extension/models/types/subscription_management.rb
+++ b/lib/project_types/extension/models/types/subscription_management.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+require 'base64'
+
+module Extension
+  module Models
+    module Types
+      class SubscriptionManagement < Models::Type
+        SCRIPT_PATH = %w(build main.js)
+
+        MISSING_FILE_ERROR = 'Could not find built extension file.'
+        SCRIPT_PREPARE_ERROR = 'An error occurred while attempting to prepare your script.'
+
+
+        def identifier
+          'SUBSCRIPTION_MANAGEMENT'
+        end
+
+        def name
+          'Subscription Management'
+        end
+
+        def config(context)
+          filepath = File.join(context.root, SCRIPT_PATH)
+          context.abort(MISSING_FILE_ERROR) unless File.exists?(filepath)
+
+          begin
+            {
+              serialized_script: Base64.strict_encode64(File.open(filepath).read.chomp)
+            }
+          rescue Exception
+            context.abort(SCRIPT_PREPARE_ERROR)
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/project_types/extension/commands/create_test.rb
+++ b/test/project_types/extension/commands/create_test.rb
@@ -7,12 +7,8 @@ module Extension
     class CreateTest < MiniTest::Test
       include TestHelpers::Partners
       include TestHelpers::FakeUI
+      include ExtensionTestHelpers::TestExtensionSetup
       include ExtensionTestHelpers::Stubs::GetOrganizations
-
-      def setup
-        super
-        ShopifyCli::ProjectType.load_type(:extension)
-      end
 
       def test_prints_help
         io = capture_io { run_cmd('create extension --help') }
@@ -29,7 +25,10 @@ module Extension
         ShopifyCli::Core::Finalize.expects(:request_cd).with('myext')
         stub_get_organizations
 
-        capture_io { run_cmd('create extension --title=myext --type=product-details --api-key=1234') }
+        capture_io do
+          run_cmd("create extension --title=myext --type=#{@test_extension_type.identifier} --api-key=1234")
+        end
+
         refute File.exists?('myext/.git'), 'Expected .git directory to be removed'
         lockfile_content = File.read('myext/yarn.lock')
         assert_equal lockfile_content, '# Dummy lockfile'

--- a/test/project_types/extension/extension_project_test.rb
+++ b/test/project_types/extension/extension_project_test.rb
@@ -19,7 +19,7 @@ module Extension
         context: @new_context,
         api_key: 'test_key',
         api_secret: 'test_secret',
-        type: 'test_type'
+        type: @type.identifier
       )
 
       assert File.exists?('.env')
@@ -29,7 +29,7 @@ module Extension
       project = ExtensionProject.current
       assert_equal 'test_key', project.env['api_key']
       assert_equal 'test_secret', project.env['secret']
-      assert_equal 'test_type', project.extension_type
+      assert_equal @type.identifier, project.extension_type.identifier
     end
 
     def test_can_write_and_read_registration_id_values
@@ -37,6 +37,10 @@ module Extension
       @project.set_registration_id(@context, 42)
 
       assert_equal 42, @project.registration_id
+    end
+
+    def test_extension_type_returns_a_type_instance
+      assert_kind_of Models::Type, @project.extension_type
     end
 
     def test_detects_if_registration_id_is_missing_or_invalid

--- a/test/project_types/extension/extension_test_helpers.rb
+++ b/test/project_types/extension/extension_test_helpers.rb
@@ -2,6 +2,8 @@
 
 module Extension
   module ExtensionTestHelpers
+    autoload :TestExtension, 'project_types/extension/extension_test_helpers/test_extension'
+    autoload :TestExtensionSetup, 'project_types/extension/extension_test_helpers/test_extension_setup'
     autoload :TempProjectSetup, 'project_types/extension/extension_test_helpers/temp_project_setup'
 
     module Stubs

--- a/test/project_types/extension/extension_test_helpers/stubs/argo_script.rb
+++ b/test/project_types/extension/extension_test_helpers/stubs/argo_script.rb
@@ -18,16 +18,15 @@ module Extension
             }
         SCRIPT
 
-        def with_stubbed_script(script: TEMPLATE_SCRIPT)
-          base_folder = "extension_test_" + SecureRandom.uuid.to_str
+        def with_stubbed_script(context, path, script = TEMPLATE_SCRIPT)
+          filepath = File.join(context.root, path)
+          directory = File.dirname(filepath)
 
-          FileUtils.mkdir_p("#{base_folder}/build")
-          FileUtils.cd(base_folder)
-          File.open('build/main.js', 'w+') { |file| file.puts(script) }
+          FileUtils.mkdir_p(directory)
+          File.open(filepath, 'w+') { |file| file.puts(script) }
           yield
         ensure
-          FileUtils.cd('..')
-          FileUtils.rm_r(base_folder)
+          FileUtils.rm_r(directory)
         end
       end
     end

--- a/test/project_types/extension/extension_test_helpers/temp_project_setup.rb
+++ b/test/project_types/extension/extension_test_helpers/temp_project_setup.rb
@@ -1,15 +1,23 @@
+# frozen_string_literal: true
+
 module Extension
   module ExtensionTestHelpers
     module TempProjectSetup
-      def setup_temp_project(api_key: 'TEST_KEY', api_secret: 'test_secret', type: 'TEST_EXTENSION')
+      include ExtensionTestHelpers::TestExtensionSetup
+
+      def setup_temp_project(api_key: 'TEST_KEY', api_secret: 'TEST_SECRET', type: @test_extension_type)
         @context = TestHelpers::FakeContext.new(root: Dir.mktmpdir)
         @api_key = api_key
         @api_secret = api_secret
         @type = type
 
-        ShopifyCli::ProjectType.load_type(:extension)
         FileUtils.cd(@context.root)
-        ExtensionProject.write_project_files(context: @context, api_key: @api_key, api_secret: @api_secret, type: @type)
+        ExtensionProject.write_project_files(
+          context: @context,
+          api_key: @api_key,
+          api_secret: @api_secret,
+          type: @type.identifier
+        )
 
         @project = ExtensionProject.current
       end

--- a/test/project_types/extension/extension_test_helpers/test_extension.rb
+++ b/test/project_types/extension/extension_test_helpers/test_extension.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Extension
+  module ExtensionTestHelpers
+    class TestExtension < Models::Type
+      def identifier
+        'TEST_EXTENSION'
+      end
+
+      def name
+        'Test Extension'
+      end
+
+      def config(_context)
+        {
+          title: 'A Test Extension Title',
+          field: 'field_for_test_extension'
+        }
+      end
+    end
+  end
+end

--- a/test/project_types/extension/extension_test_helpers/test_extension_setup.rb
+++ b/test/project_types/extension/extension_test_helpers/test_extension_setup.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Extension
+  module ExtensionTestHelpers
+    module TestExtensionSetup
+      def setup
+        ShopifyCli::ProjectType.load_type(:extension)
+
+        @test_extension_type = ExtensionTestHelpers::TestExtension.new
+        Models::Type.repository[@test_extension_type.identifier] = @test_extension_type
+        super
+      end
+
+      def teardown
+        super
+        Models::Type.repository.delete(ExtensionTestHelpers::TestExtension.new.identifier)
+      end
+    end
+  end
+end

--- a/test/project_types/extension/forms/create_test.rb
+++ b/test/project_types/extension/forms/create_test.rb
@@ -6,12 +6,12 @@ module Extension
   module Forms
     class CreateTest < MiniTest::Test
       include TestHelpers::Partners
+      include ExtensionTestHelpers::TestExtensionSetup
       include ExtensionTestHelpers::Stubs::GetOrganizations
 
       def setup
         super
         stub_get_organizations
-        ShopifyCli::ProjectType.load_type(:extension)
       end
 
       def returns_defined_attributes_if_valid
@@ -20,14 +20,9 @@ module Extension
         assert_equal form.type, 'product-details'
       end
 
-      def test_accepts_product_details_as_type
-        form = ask
-        assert_equal form.type, 'product-details'
-      end
-
-      def test_accepts_customer_details_as_type
-        form = ask(type: 'customer-details')
-        assert_equal form.type, 'customer-details'
+      def test_accepts_any_valid_extension_type
+        form = ask(type: @test_extension_type.identifier)
+        assert_equal form.type, @test_extension_type.identifier
       end
 
       def test_prompts_the_user_to_choose_a_title_if_no_title_was_provided
@@ -78,7 +73,7 @@ module Extension
 
       private
 
-      def ask(title: ['test-extension'], type: 'product-details', api_key: '1234')
+      def ask(title: ['test-extension'], type: @test_extension_type.identifier, api_key: '1234')
         Create.ask(
           @context,
           [],

--- a/test/project_types/extension/models/type_test.rb
+++ b/test/project_types/extension/models/type_test.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+module Extension
+  module Models
+    class TypeTest < MiniTest::Test
+      include ExtensionTestHelpers::TestExtensionSetup
+
+      def test_loads_all_extension_types_within_types_folder
+        production_extension_type_count = 2
+        test_extension_type_count = 1
+        total_extension_type_count = production_extension_type_count + test_extension_type_count
+
+        assert_equal total_extension_type_count, Models::Type.repository.size
+      end
+
+      def test_can_load_type_by_identifier
+        assert_equal @test_extension_type.identifier, Models::Type.load_type(@test_extension_type.identifier).identifier
+      end
+
+      def test_valid_determines_if_a_type_is_valid
+        assert Models::Type.valid?(@test_extension_type.identifier)
+        refute Models::Type.valid?('INVALID')
+      end
+
+      def test_all_identifiers_are_defined_and_uppercase
+        Models::Type.repository.values.each do |type|
+          assert_equal type.identifier.upcase, type.identifier
+          refute_empty type.identifier.strip
+        end
+      end
+
+      def test_all_names_are_defined
+        Models::Type.repository.values.each do |type|
+          refute_empty type.name.strip
+        end
+      end
+
+      def test_raises_not_implemented_error_for_required_methods
+        assert_raises(NotImplementedError) { Models::Type.new.identifier }
+        assert_raises(NotImplementedError) { Models::Type.new.name }
+        assert_raises(NotImplementedError) { Models::Type.new.config(@context) }
+      end
+
+      def test_valid_extension_contexts_returns_empty_array
+        assert_empty Models::Type.new.valid_extension_contexts
+      end
+
+      def test_extension_context_returns_nil
+        assert_nil Models::Type.new.extension_context(@context)
+      end
+    end
+  end
+end

--- a/test/project_types/extension/models/types/subscription_management_test.rb
+++ b/test/project_types/extension/models/types/subscription_management_test.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+require 'test_helper'
+require 'project_types/extension/extension_test_helpers'
+require 'base64'
+
+module Extension
+  module Models
+    module Types
+      class SubscriptionManagementTest < MiniTest::Test
+        include TestHelpers::FakeUI
+        include ExtensionTestHelpers::TempProjectSetup
+        include ExtensionTestHelpers::Stubs::ArgoScript
+
+        def setup
+          super
+          setup_temp_project
+          @subscription_management = Models::Type.load_type('SUBSCRIPTION_MANAGEMENT')
+        end
+
+        def test_aborts_with_error_if_script_file_doesnt_exist
+          error = assert_raises ShopifyCli::Abort do
+            @subscription_management.config(@context)
+          end
+
+          assert error.message.include?(SubscriptionManagement::MISSING_FILE_ERROR)
+        end
+
+        def test_aborts_with_error_if_script_serialization_fails
+          File.stubs(:exists?).returns(true)
+          Base64.stubs(:strict_encode64).raises(IOError)
+
+          error = assert_raises(ShopifyCli::Abort) { @subscription_management.config(@context) }
+          assert error.message.include?(SubscriptionManagement::SCRIPT_PREPARE_ERROR)
+        end
+
+        def test_aborts_with_error_if_file_read_fails
+          File.stubs(:exists?).returns(true)
+          File.any_instance.stubs(:read).raises(IOError)
+
+          error = assert_raises(ShopifyCli::Abort) { @subscription_management.config(@context) }
+          assert error.message.include?(SubscriptionManagement::SCRIPT_PREPARE_ERROR)
+        end
+
+        def test_encodes_script_into_context_if_it_exists
+          with_stubbed_script(@context, SubscriptionManagement::SCRIPT_PATH) do
+            config = @subscription_management.config(@context)
+
+            assert_equal [:serialized_script], config.keys
+            assert_equal Base64.strict_encode64(TEMPLATE_SCRIPT.chomp), config[:serialized_script]
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### WHY are these changes introduced?
Part of: https://github.com/Shopify/app-extension-libs/issues/299
Closes: https://github.com/Shopify/app-extension-libs/issues/344
Closes: https://github.com/Shopify/app-extension-libs/issues/343
Follows: https://github.com/Shopify/shopify-app-cli-extensions/pull/13
Next: https://github.com/Shopify/shopify-app-cli-extensions/pull/15

This PR is the next step towards getting the `deploy` method functional. It adds in the concept of `ExtensionTypes` which are able to control communication with `Partners` based on the type of extension.

### WHAT is this pull request doing?
- Adds the concepts of `ExtensionType`
  - Extension types are autoloaded when necessary following a common CLI pattern
  - Adding a new extension type only requires adding a new file in the `models/types` folder
- Added the `SubscriptionManagement` extension type
- Created a temporary `ShopifyHostedAppLink` extension type
- `deploy` command now defers to extension type to create `config`
- Updated the `create` form to use the new extension types
- Improved test setup to allow usage of `TestExtension`
- TestProjectSetup now uses `TestExtension` by default