### PR TITLE
Refactoring create form

### DIFF
--- a/lib/project_types/extension/cli.rb
+++ b/lib/project_types/extension/cli.rb
@@ -14,6 +14,7 @@ module Extension
   end
 
   module Tasks
+    autoload :GetApps, Project.project_filepath('tasks/get_apps')
     autoload :CreateExtension, Project.project_filepath('tasks/create_extension')
     autoload :UpdateDraft, Project.project_filepath('tasks/update_draft')
   end
@@ -23,6 +24,7 @@ module Extension
   end
 
   module Models
+    autoload :App, Project.project_filepath('models/app')
     autoload :Registration, Project.project_filepath('models/registration')
     autoload :Version, Project.project_filepath('models/version')
     autoload :Type, Project.project_filepath('models/type')

--- a/lib/project_types/extension/commands/create.rb
+++ b/lib/project_types/extension/commands/create.rb
@@ -11,12 +11,12 @@ module Extension
 
       def call(args, _)
         with_create_form(args) do |form|
-          build(form.title)
+          build(form.name)
 
           ExtensionProject.write_project_files(
             context: @ctx,
-            api_key: form.app["apiKey"],
-            api_secret: form.app["apiSecretKeys"].first["secret"],
+            api_key: form.app.api_key,
+            api_secret: form.app.secret,
             type: form.type
           )
         end

--- a/lib/project_types/extension/forms/create.rb
+++ b/lib/project_types/extension/forms/create.rb
@@ -5,12 +5,23 @@ module Extension
     class Create < ShopifyCli::Form
       flag_arguments :title, :type, :api_key
 
+      ASK_TITLE = 'What is your extension\'s name?'
+      ASK_TYPE = 'What type of extension would you like to create?'
+      INVALID_TYPE = 'Invalid extension type.'
+      ASK_APP = 'Which app would you like to associate with the extension?'
+      NO_APPS = 'There are no registered apps. Create an app and try again'
+      INVALID_API_KEY = 'The api key does not match any of the existing apps'
+
       attr_reader :app
 
       def ask
         self.title = ask_title
         self.type = ask_type
         self.app = ask_app
+      end
+
+      def name
+        @name ||= self.title.strip.gsub(/( )/, '_').downcase
       end
 
       protected
@@ -20,39 +31,33 @@ module Extension
       private
 
       def ask_title
-        return title unless title.nil?
-        CLI::UI::Prompt.ask('Extension Name')
+        return title unless title.nil? || title.strip.empty?
+        CLI::UI::Prompt.ask(ASK_TITLE)
       end
 
       def ask_type
         return type if Models::Type.valid?(type)
-        raise(ShopifyCli::Abort, 'Invalid extension type.') unless type.nil?
+        ctx.puts(INVALID_TYPE) unless type.nil?
 
-        CLI::UI::Prompt.ask('What type of extension would you like to create?') do |handler|
-          Models::Type.repository.values.each do |type|
+        CLI::UI::Prompt.ask(ASK_TYPE) do |handler|
+          Models::Type.all.each do |type|
             handler.option(type.name) { type.identifier }
           end
         end
       end
 
       def ask_app
-        orgs = ShopifyCli::Helpers::Organizations.fetch_with_app(@ctx)
-        orgs_with_apps = orgs.select {|org| org['apps'].any?}
-        ctx.abort('There is no registered app. Create an app and try again') unless orgs_with_apps.any?
+        apps = Tasks::GetApps.call(context: ctx)
+        ctx.abort(NO_APPS) if apps.empty?
 
         if !api_key.nil?
-          app = orgs_with_apps.reduce(nil) do |app, org|
-            break app if app
-            org.fetch('apps', []).find { |app| app['apiKey'] == api_key }
-          end
-          ctx.abort('The api key does not match any of the existing apps') if app.nil?
-          return app
+          found_app = apps.find { |app| app.api_key == api_key }
+          ctx.abort(INVALID_API_KEY) if found_app.nil?
+          found_app
         else
-          CLI::UI::Prompt.ask('Which app would you like to associate with the extension?') do |handler|
-            orgs.each do |org|
-              org['apps'].each do |app|
-                handler.option(app['title'] + " by #{org['businessName'].to_s}") { app }
-              end
+          CLI::UI::Prompt.ask(ASK_APP) do |handler|
+            apps.each do |app|
+              handler.option("#{app.title} by #{app.business_name}") { app }
             end
           end
         end

--- a/lib/project_types/extension/models/app.rb
+++ b/lib/project_types/extension/models/app.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Extension
+  module Models
+    class App
+      include SmartProperties
+
+      property! :api_key, accepts: String
+      property! :secret, accepts: String
+      property :title, accepts: String
+      property :business_name, accepts: String
+    end
+  end
+end

--- a/lib/project_types/extension/tasks/get_apps.rb
+++ b/lib/project_types/extension/tasks/get_apps.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+require 'shopify_cli'
+
+module Extension
+  module Tasks
+    class GetApps < ShopifyCli::Task
+      def call(context:)
+        organizations = ShopifyCli::Helpers::Organizations.fetch_with_app(context)
+        apps_from_organizations(organizations)
+      end
+
+      private
+
+      def apps_from_organizations(organizations)
+        organizations.flat_map do |organization|
+          return [] unless organization.key?('apps') && organization['apps'].any?
+          apps_owned_by_organization(organization)
+        end
+      end
+
+      def apps_owned_by_organization(organization)
+        organization['apps'].map do |app|
+          Models::App.new(
+            api_key: app['apiKey'],
+            secret: app["apiSecretKeys"].first["secret"],
+            title: app['title'],
+            business_name: organization['businessName']
+          )
+        end
+      end
+    end
+  end
+end

--- a/test/project_types/extension/extension_test_helpers/stubs/get_organizations.rb
+++ b/test/project_types/extension/extension_test_helpers/stubs/get_organizations.rb
@@ -6,7 +6,7 @@ module Extension
       module GetOrganizations
         include TestHelpers::Partners
 
-        def stub_get_organizations
+        def stub_get_organizations(organization_name: 'one', app_title: 'App', api_key: '1234', api_secret: '5678')
           stub_partner_req(
             'all_orgs_with_apps',
             resp: {
@@ -14,8 +14,8 @@ module Extension
                 organizations: {
                   nodes: [
                     {
-                      'id': 421,
-                      'businessName': "one",
+                      'id': rand(9999),
+                      'businessName': organization_name,
                       'stores': {
                         'nodes': [
                           { 'shopDomain': 'store.myshopify.com' },
@@ -23,11 +23,11 @@ module Extension
                       },
                       'apps': {
                         nodes: [{
-                                  id: 123,
-                                  title: 'app',
-                                  'apiKey': '1234',
+                                  id: rand(9999),
+                                  title: app_title,
+                                  'apiKey': api_key,
                                   'apiSecretKeys': [{
-                                                      'secret': "1233",
+                                                      'secret': api_secret,
                                                     }],
                                 }],
                       },
@@ -37,6 +37,43 @@ module Extension
               },
             },
           )
+        end
+
+        def stub_no_organizations
+          stub_partner_req(
+            'all_orgs_with_apps',
+            resp: {
+              data: {
+                organizations: {
+                  nodes: []
+                },
+              },
+            },
+          )
+        end
+
+        def stub_no_apps(organization_name)
+          stub_partner_req(
+            'all_orgs_with_apps',
+            resp: {
+              data: {
+                organizations: {
+                  nodes: [
+                    {
+                      'id': rand(9999),
+                      'businessName': organization_name,
+                      'stores': {
+                        'nodes': [
+                          { 'shopDomain': 'store.myshopify.com' },
+                        ],
+                      },
+                      'apps': { nodes: [] },
+                    },
+                  ],
+                },
+              },
+            },
+            )
         end
       end
     end

--- a/test/project_types/extension/forms/create_test.rb
+++ b/test/project_types/extension/forms/create_test.rb
@@ -5,19 +5,34 @@ require 'project_types/extension/extension_test_helpers'
 module Extension
   module Forms
     class CreateTest < MiniTest::Test
-      include TestHelpers::Partners
+      include TestHelpers::FakeUI
       include ExtensionTestHelpers::TestExtensionSetup
-      include ExtensionTestHelpers::Stubs::GetOrganizations
 
       def setup
         super
-        stub_get_organizations
+        @app = Models::App.new(title: 'Fake', api_key: '1234', secret: '4567', business_name: 'Fake Business')
+        Tasks::GetApps.any_instance.expects(:call).with(context: @context).returns([@app]).at_least_once
       end
 
       def returns_defined_attributes_if_valid
         form = ask
         assert_equal form.title, 'test-extension'
-        assert_equal form.type, 'product-details'
+        assert_equal form.type, @test_extension_type.identifier
+      end
+
+      def test_prompts_the_user_to_choose_a_title_if_no_title_was_provided
+        CLI::UI::Prompt.expects(:ask).with(Forms::Create::ASK_TITLE).times(3)
+
+        capture_io { ask(title: nil) }
+        capture_io { ask(title: "") }
+        capture_io { ask(title: " ") }
+      end
+
+      def test_name_is_a_lowercase_underscored_version_of_title
+        assert_equal 'demo', ask(title: 'Demo').name
+        assert_equal 'spaces', ask(title: ' Spaces ').name
+        assert_equal 'demo_extension', ask(title: 'Demo Extension').name
+        assert_equal 'testlongstring', ask(title: 'TestLongString').name
       end
 
       def test_accepts_any_valid_extension_type
@@ -25,38 +40,40 @@ module Extension
         assert_equal form.type, @test_extension_type.identifier
       end
 
-      def test_prompts_the_user_to_choose_a_title_if_no_title_was_provided
-        CLI::UI::Prompt.expects(:ask).with('Extension Name')
-
-        capture_io do
-          ask(title: nil)
-        end
-      end
-
       def test_prompts_the_user_to_choose_a_type_if_an_unknown_type_was_provided_as_flag
+        CLI::UI::Prompt::expects(:ask).with(Forms::Create::ASK_TYPE)
+
         io = capture_io do
           ask(type: 'unknown-type')
         end
 
-        assert_match('Invalid extension type.', io.join)
+        assert_match(Forms::Create::INVALID_TYPE, io.join)
       end
 
       def test_prompts_the_user_to_choose_a_type_if_no_type_was_provided
-        CLI::UI::Prompt.expects(:ask).with('What type of extension would you like to create?')
+        CLI::UI::Prompt.expects(:ask).with(Forms::Create::ASK_TYPE)
 
         capture_io do
           ask(type: nil)
         end
       end
 
+      def test_informs_user_if_there_are_no_apps
+        Tasks::GetApps.any_instance.unstub(:call)
+        Tasks::GetApps.any_instance.expects(:call).with(context: @context).returns([]).once
+
+        output = capture_io { ask }
+
+        assert_match Forms::Create::NO_APPS, output.join
+      end
+
       def test_accepts_the_api_key_to_associate_with_extension
-        form = ask
-        orgs = ShopifyCli::Helpers::Organizations.fetch_with_app(@context)
-        assert_equal form.app['apiKey'], orgs.first['apps'].first['apiKey']
+        form = ask(api_key: '1234')
+        assert_equal form.app, @app
       end
 
       def test_prompts_the_user_to_choose_an_app_to_associate_with_extension_if_no_app_is_provided
-        CLI::UI::Prompt.expects(:ask).with('Which app would you like to associate with the extension?')
+        CLI::UI::Prompt.expects(:ask).with(Forms::Create::ASK_APP)
 
         capture_io do
           ask(api_key: nil)
@@ -68,12 +85,12 @@ module Extension
           ask(api_key: '00001')
         end
 
-        assert_match('The api key does not match any of the existing apps', io.join)
+        assert_match(Forms::Create::INVALID_API_KEY, io.join)
       end
 
       private
 
-      def ask(title: ['test-extension'], type: @test_extension_type.identifier, api_key: '1234')
+      def ask(title: 'test-extension', type: @test_extension_type.identifier, api_key: @app.api_key)
         Create.ask(
           @context,
           [],

--- a/test/project_types/extension/tasks/get_apps_test.rb
+++ b/test/project_types/extension/tasks/get_apps_test.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+require 'test_helper'
+require 'project_types/extension/extension_test_helpers'
+
+module Extension
+  module Tasks
+    class GetAppsTest < MiniTest::Test
+      include TestHelpers::Partners
+      include ExtensionTestHelpers::Stubs::GetOrganizations
+
+      def setup
+        super
+        ShopifyCli::ProjectType.load_type(:extension)
+      end
+
+      def test_loads_all_apps_into_a_list_from_organizations
+        stub_get_organizations(
+          organization_name: 'Organization One',
+          app_title: 'App One',
+          api_key: '1234',
+          api_secret: '5678'
+        )
+
+        app_list = Tasks::GetApps.call(context: @context)
+        app = app_list.first
+
+        assert_equal 1, app_list.size
+        assert_equal 'Organization One', app.business_name
+        assert_equal 'App One', app.title
+        assert_equal '1234', app.api_key
+        assert_equal '5678', app.secret
+      end
+
+      def test_returns_empty_array_if_there_are_no_organizations
+        stub_no_organizations
+
+        assert_empty Tasks::GetApps.call(context: @context)
+      end
+
+      def test_returns_empty_array_if_there_are_no_apps
+        stub_no_apps(organization_name: 'Organization One')
+
+        assert_empty Tasks::GetApps.call(context: @context)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### WHY are these changes introduced?
Chain: https://github.com/Shopify/shopify-app-cli-extensions/pull/13 -> https://github.com/Shopify/shopify-app-cli-extensions/pull/14 -> Here

There were some difficulties tracking the logic of the extension create form. This cleans up that form to try to make it a bit more readable overall.

### WHAT is this pull request doing?
- Refactoring extension create form
- Adding a new Task built for fetching a list of apps
- Introduce the App model for easier field access
- Add the `name` attribute to the form which can be used to create a folder from a title

