### PR TITLE
Syncing CLI with Partners Dashboard

### DIFF
--- a/lib/graphql/extension_create.graphql
+++ b/lib/graphql/extension_create.graphql
@@ -1,5 +1,5 @@
-mutation ExtensionCreate($api_key: String!, $type: ExtensionType!, $title: String!) {
-  extensionCreate(input: {appKey: $api_key, type: $type, title: $title, config: {}}) {
+mutation ExtensionCreate($api_key: String!, $type: ExtensionType!, $title: String!, $config: JSON!, $extension_context: String) {
+  extensionCreate(input: {apiKey: $api_key, type: $type, title: $title, config: $config, context: $extension_context}) {
     extensionRegistration {
       id
       type

--- a/lib/graphql/extension_update_draft.graphql
+++ b/lib/graphql/extension_update_draft.graphql
@@ -1,5 +1,5 @@
 mutation ExtensionUpdateDraft($api_key: String!, $registration_id: ID!, $config: JSON!, $context: String) {
-  extensionUpdateDraft(input: {appKey: $api_key, registrationId: $registration_id, config: $config, context: $context}) {
+  extensionUpdateDraft(input: {apiKey: $api_key, registrationId: $registration_id, config: $config, context: $context}) {
     extensionVersion {
       registrationId
       context

--- a/lib/project_types/extension/cli.rb
+++ b/lib/project_types/extension/cli.rb
@@ -16,6 +16,7 @@ module Extension
   end
 
   module Tasks
+    autoload :UserErrors, Project.project_filepath('tasks/user_errors')
     autoload :GetApps, Project.project_filepath('tasks/get_apps')
     autoload :CreateExtension, Project.project_filepath('tasks/create_extension')
     autoload :UpdateDraft, Project.project_filepath('tasks/update_draft')

--- a/lib/project_types/extension/commands/deploy.rb
+++ b/lib/project_types/extension/commands/deploy.rb
@@ -24,7 +24,8 @@ module Extension
           context: @ctx,
           api_key: @project.env['api_key'],
           registration_id: @project.registration_id,
-          config: @project.extension_type.config(@ctx)
+          config: @project.extension_type.config(@ctx),
+          extension_context: @project.extension_type.extension_context(@ctx)
         )
       end
 
@@ -34,7 +35,8 @@ module Extension
           api_key: @project.env['api_key'],
           type: @project.extension_type.identifier,
           title: 'Testing the CLI',
-          config: @project.extension_type.config(@ctx)
+          config: @project.extension_type.config(@ctx),
+          extension_context: @project.extension_type.extension_context(@ctx)
         )
 
         @project.set_registration_id(@ctx, registration.id)

--- a/lib/project_types/extension/extension_project.rb
+++ b/lib/project_types/extension/extension_project.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require 'shopify_cli'
+require 'forwardable'
 
 module Extension
   class ExtensionProject

--- a/lib/project_types/extension/tasks/update_draft.rb
+++ b/lib/project_types/extension/tasks/update_draft.rb
@@ -4,28 +4,39 @@ require 'shopify_cli'
 module Extension
   module Tasks
     class UpdateDraft < ShopifyCli::Task
+      include UserErrors
+
+      GRAPHQL_FILE = 'extension_update_draft'
+      REGISTRATION_ID_FIELD = 'registrationId'
+      CONTEXT_FIELD = 'context'
+      RESPONSE_FIELD = %w(data extensionUpdateDraft)
+      VERSION_FIELD = 'extensionVersion'
+      PARSE_ERROR = 'Unable to parse response from Partners Dashboard.'
+
       def call(context:, api_key:, registration_id:, config:, extension_context:)
-        response = ShopifyCli::PartnersAPI.query(
-          context,
-          'extension_update_draft',
+        input = {
           api_key: api_key,
           registration_id: registration_id,
-          config: config,
-          context: extension_context
-        )
+          config: JSON.generate(config),
+          extension_context: extension_context
+        }
 
-        response_to_version(response)
+        response = ShopifyCli::PartnersAPI.query(context, GRAPHQL_FILE, input).dig(*RESPONSE_FIELD)
+        context.abort(PARSE_ERROR) if response.nil?
+
+        abort_if_user_errors(context, response)
+        response_to_version(context, response)
       end
 
       private
 
-      def response_to_version(response)
-        version_hash = response.dig('data', 'extensionUpdateDraft', 'extensionVersion')
-        return nil if version_hash.nil?
+      def response_to_version(context, response)
+        version_hash = response.dig(VERSION_FIELD)
+        context.abort(PARSE_ERROR) if version_hash.nil?
 
         Models::Version.new(
-          registration_id: version_hash['registrationId'].to_i,
-          context: version_hash['context']
+          registration_id: version_hash[REGISTRATION_ID_FIELD].to_i,
+          context: version_hash[CONTEXT_FIELD]
         )
       end
     end

--- a/lib/project_types/extension/tasks/user_errors.rb
+++ b/lib/project_types/extension/tasks/user_errors.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+require 'shopify_cli'
+
+module Extension
+  module Tasks
+    module UserErrors
+      USER_ERRORS_FIELD = 'userErrors'
+      MESSAGE_FIELD = 'message'
+      USER_ERRORS_PARSE_ERROR = 'Unable to parse errors from server.'
+
+      def abort_if_user_errors(context, response)
+        return if response.nil?
+
+        user_errors = response.dig(USER_ERRORS_FIELD)
+        output_all_user_errors(context, user_errors)
+      end
+
+      private
+
+      def output_all_user_errors(context, user_errors)
+        return if user_errors.nil? || user_errors.empty?
+        last_user_error = user_errors.pop
+
+        user_errors.each { |user_error| puts_user_error(context, user_error) }
+        abort_user_error(context, last_user_error)
+      end
+
+      def puts_user_error(context, user_error)
+        output_user_error(context, user_error) { |message| context.puts("{{x}} #{message}") }
+      end
+
+      def abort_user_error(context, user_error)
+        output_user_error(context, user_error) { |message| context.abort(message) }
+      end
+
+      def output_user_error(context, user_error)
+        if user_error.key?(MESSAGE_FIELD)
+          yield(user_error[MESSAGE_FIELD])
+        else
+          context.abort(USER_ERRORS_PARSE_ERROR)
+        end
+      end
+    end
+  end
+end

--- a/test/project_types/extension/commands/deploy_test.rb
+++ b/test/project_types/extension/commands/deploy_test.rb
@@ -33,7 +33,8 @@ module Extension
             api_key: @api_key,
             type: @type.identifier,
             title: 'Testing the CLI',
-            config: @type.config(@context)
+            config: @type.config(@context),
+            extension_context: @type.extension_context(@context)
           )
           .returns(@registration).once
 
@@ -49,7 +50,8 @@ module Extension
           context: @context,
           api_key: @api_key,
           registration_id: @registration.id,
-          config: @type.config(@context)
+          config: @type.config(@context),
+          extension_context: @type.extension_context(@context)
         ).once
 
         run_cmd('deploy')

--- a/test/project_types/extension/extension_test_helpers/stubs/create_extension.rb
+++ b/test/project_types/extension/extension_test_helpers/stubs/create_extension.rb
@@ -6,41 +6,45 @@ module Extension
       module CreateExtension
         include TestHelpers::Partners
 
-        def stub_create_extension(api_key:, type:, title:)
+        def stub_create_extension(api_key:, type:, title:, config:, extension_context: nil)
           stub_partner_req(
             'extension_create',
             variables: {
               api_key: api_key,
               type: type,
-              title: title
+              title: title,
+              config: JSON.generate(config),
+              extension_context: extension_context
             },
             resp: {
-              data: {
-                extensionCreate: {
-                  extensionRegistration: {
-                    id: rand(9999),
-                    type: type,
-                    title: title,
-                  },
-                  userErrors: []
-                },
-              },
+              data: yield(title, type, config, extension_context)
             }
           )
         end
 
-        def stub_create_extension_with_errors(api_key:, type:, title:, errors: [])
-          stub_partner_req(
-            'extension_create',
-            variables: {
-              api_key: api_key,
-              type: type,
-              title: title
-            },
-            resp: {
-              errors: errors
+        def stub_create_extension_success(**args)
+          stub_create_extension(args) do |title, type|
+            {
+              extensionCreate: {
+                extensionRegistration: {
+                  id: rand(9999),
+                  type: type,
+                  title: title
+                },
+                userErrors: []
+              },
             }
-          )
+          end
+        end
+
+        def stub_create_extension_failure(userErrors:, **args)
+          stub_create_extension(args) do
+            {
+              extensionCreate: {
+                userErrors: userErrors
+              },
+            }
+          end
         end
       end
     end

--- a/test/project_types/extension/extension_test_helpers/stubs/update_draft.rb
+++ b/test/project_types/extension/extension_test_helpers/stubs/update_draft.rb
@@ -6,42 +6,42 @@ module Extension
       module UpdateDraft
         include TestHelpers::Partners
 
-        def stub_update_draft(api_key:, registration_id:, config:, context:)
-          stub_partner_req(
-            'extension_update_draft',
+        def stub_update_draft(registration_id:, config:, extension_context: nil, api_key: 'FAKE_API_KEY')
+          stub_partner_req(Tasks::UpdateDraft::GRAPHQL_FILE,
             variables: {
               api_key: api_key,
               registration_id: registration_id,
-              config: config,
-              context: context
+              config: JSON.generate(config),
+              extension_context: extension_context
             },
             resp: {
-              data: {
-                extensionUpdateDraft: {
-                  extensionVersion: {
-                    registrationId: registration_id,
-                    context: context
-                  },
-                  userErrors: []
-                },
-              },
+              data: yield(registration_id, config, extension_context)
             }
           )
         end
 
-        def stub_update_draft_with_errors(api_key:, registration_id:, config:, context:, errors: [])
-          stub_partner_req(
-            'extension_update_draft',
-            variables: {
-              api_key: api_key,
-              registration_id: registration_id,
-              config: config,
-              context: context
-            },
-            resp: {
-              errors: errors
+        def stub_update_draft_success(**args)
+          stub_update_draft(args) do |registration_id, config, extension_context|
+            {
+              extensionUpdateDraft: {
+                extensionVersion: {
+                  registrationId: registration_id,
+                  context: extension_context
+                },
+                Tasks::UserErrors::USER_ERRORS_FIELD => []
+              }
             }
-          )
+          end
+        end
+
+        def stub_update_draft_failure(errors:, **args)
+          stub_update_draft(args) do
+            {
+              extensionUpdateDraft: {
+                Tasks::UserErrors::USER_ERRORS_FIELD => errors
+              }
+            }
+          end
         end
       end
     end

--- a/test/project_types/extension/tasks/user_errors_test.rb
+++ b/test/project_types/extension/tasks/user_errors_test.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+module Extension
+  module Tasks
+    class UserErrorsTest < MiniTest::Test
+      include TestHelpers::FakeUI
+
+      def setup
+        super
+        ShopifyCli::ProjectType.load_type(:extension)
+
+        @test_user_errors = Object.new.extend(Tasks::UserErrors)
+      end
+
+      def test_does_not_output_or_abort_if_no_user_errors_are_present
+        @context.expects(:puts).never
+        @context.expects(:abort).never
+
+        @test_user_errors.abort_if_user_errors(@context, {})
+        @test_user_errors.abort_if_user_errors(@context, {UserErrors::USER_ERRORS_FIELD => []})
+        @test_user_errors.abort_if_user_errors(@context, nil)
+      end
+
+      def test_aborts_with_message_if_only_one_user_error_present
+        fake_response = {
+          UserErrors::USER_ERRORS_FIELD => [
+            {field: ['field'], UserErrors::MESSAGE_FIELD => 'An error has occurred.'}
+          ]
+        }
+
+        @context.expects(:abort).with('An error has occurred.').once
+        @test_user_errors.abort_if_user_errors(@context, fake_response)
+      end
+
+      def test_no_matter_how_many_errors_only_last_error_calls_abort
+        fake_errors = Array.new(6, {field: ['field'], UserErrors::MESSAGE_FIELD => 'An error has occurred.'})
+        fake_errors << {field: ['field2'], UserErrors::MESSAGE_FIELD => 'Last error abort.'}
+        fake_response = { UserErrors::USER_ERRORS_FIELD => fake_errors }
+
+        @context.expects(:puts).with('{{x}} An error has occurred.').times(6)
+        @context.expects(:abort).with('Last error abort.').once
+
+        @test_user_errors.abort_if_user_errors(@context, fake_response)
+      end
+
+      def test_aborts_with_parse_error_message_if_user_errors_parsing_fails
+        fake_response = {
+          UserErrors::USER_ERRORS_FIELD => [
+            {field: ['field'], wrong_message_field: 'An error has occurred.'}
+          ]
+        }
+
+        @context.expects(:abort).with(UserErrors::USER_ERRORS_PARSE_ERROR).once
+        @test_user_errors.abort_if_user_errors(@context, fake_response)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### WHY are these changes introduced?
Part of: https://github.com/Shopify/app-extension-libs/issues/299

After the addition of the final API methods on Partners Dashboard it was time to sync the CLI with the live APIs. This PR updates the APIs to work with the live APIs and adds user error handling.

### WHAT is this pull request doing?
- Add user error handling
- Add user error testing
- Update APIs to work with live APIs
