### PR TITLE
Basic hidden serve command

### DIFF
--- a/lib/project_types/extension/cli.rb
+++ b/lib/project_types/extension/cli.rb
@@ -5,11 +5,13 @@ module Extension
 
     register_command('Extension::Commands::Pack', "pack")
     register_command('Extension::Commands::Deploy', "deploy")
+    register_command('Extension::Commands::Serve', "serve")
   end
 
   module Commands
     autoload :Create, Project.project_filepath('commands/create')
     autoload :Pack, Project.project_filepath('commands/pack')
+    autoload :Serve, Project.project_filepath('commands/serve')
     autoload :Deploy, Project.project_filepath('commands/deploy')
   end
 

--- a/lib/project_types/extension/commands/serve.rb
+++ b/lib/project_types/extension/commands/serve.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Extension
+  module Commands
+    class Serve < ShopifyCli::Command
+      hidden_command
+
+      YARN_SERVE_COMMAND = %w(yarn server)
+      NPM_SERVE_COMMAND = %w(npm run-script server)
+
+      SERVE_FAILURE_MESSAGE = 'Failed to run extension code for testing.'
+
+      def call(args, command_name)
+        CLI::UI::Frame.open('Running your extension') do
+          @ctx.abort(SERVE_FAILURE_MESSAGE) unless serve.success?
+        end
+      end
+
+      def self.help
+        <<~HELP
+          Serve your extension locally for testing.
+            Usage: {{command:#{ShopifyCli::TOOL_NAME} serve}}
+        HELP
+      end
+
+      private
+
+      def yarn_available?
+        @yarn_availability ||= JsDeps.new(ctx: @ctx).yarn?
+      end
+
+      def serve
+        serve_command = yarn_available? ? YARN_SERVE_COMMAND : NPM_SERVE_COMMAND
+        @ctx.system(*serve_command)
+      end
+    end
+  end
+end

--- a/test/project_types/extension/commands/serve_test.rb
+++ b/test/project_types/extension/commands/serve_test.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+module Extension
+  module Commands
+    class ServeTest < MiniTest::Test
+      include TestHelpers::Partners
+      include TestHelpers::FakeUI
+
+      class FakeProcessStatus
+        def initialize(success)
+          @success = success
+        end
+
+        def success?
+          @success
+        end
+      end
+
+      def setup
+        super
+        ShopifyCli::ProjectType.load_type(:extension)
+      end
+
+      def test_prints_help
+        @context.expects(:puts).with(Extension::Commands::Serve.help)
+        run_cmd('help serve')
+      end
+
+      def test_uses_yarn_when_yarn_is_available
+        Serve.any_instance.stubs(:yarn_available?).returns(true)
+        @context.expects(:system).with(*Serve::YARN_SERVE_COMMAND).returns(FakeProcessStatus.new(true))
+
+        run_cmd('serve')
+      end
+
+      def test_uses_npm_when_yarn_is_unavailable
+        Serve.any_instance.stubs(:yarn_available?).returns(false)
+        @context.expects(:system).with(*Serve::NPM_SERVE_COMMAND).returns(FakeProcessStatus.new(true))
+
+        run_cmd('serve')
+      end
+
+      def test_aborts_and_informs_the_user_when_serve_fails
+        Serve.any_instance.stubs(:yarn_available?).returns(true)
+        @context.expects(:system).with(*Serve::YARN_SERVE_COMMAND).returns(FakeProcessStatus.new(false))
+        @context.expects(:abort).with(Serve::SERVE_FAILURE_MESSAGE)
+
+        run_cmd('serve')
+      end
+    end
+  end
+end


### PR DESCRIPTION
### WHY are these changes introduced?
Adds the `serve` command. This currently does the bare minimum and just outputs the standard output. UX hasn't been designed for `serve` yet.

### WHAT is this pull request doing?
- Adds the `serve` command
- Keeps `serve` as a hidden command until we know it is going to make it
- Includes only basic output until UX is designed