### PR TITLE
Cleaning up extension create

### DIFF
--- a/lib/project_types/extension/commands/create.rb
+++ b/lib/project_types/extension/commands/create.rb
@@ -51,8 +51,7 @@ module Extension
         @ctx.root = File.join(@ctx.root, name)
 
         begin
-          @ctx.rm_r(File.join(@ctx.root, '.git'))
-          @ctx.rm(File.join(@ctx.root, 'yarn.lock'))
+          @ctx.rm_r('.git')
         rescue Errno::ENOENT => e
           @ctx.debug(e)
         end

--- a/test/project_types/extension/commands/create_test.rb
+++ b/test/project_types/extension/commands/create_test.rb
@@ -32,8 +32,7 @@ module Extension
         end
 
         refute File.exists?('myext/.git'), 'Expected .git directory to be removed'
-        lockfile_content = File.read('myext/yarn.lock')
-        assert_equal lockfile_content, '# Dummy lockfile'
+        assert File.exists?('myext/yarn.lock'), 'Expected yarn.lock directory to be removed'
 
         assert_match Content::Create::READY_TO_START % name, io.join
         assert_match Content::Create::LEARN_MORE % @test_extension_type.name, io.join


### PR DESCRIPTION
### WHY are these changes introduced?
Part of: https://github.com/Shopify/app-extension-libs/issues/323

After the last upstream rebase a few changes had to be made to realign us with the CLI.

### WHAT is this pull request doing?
Matching extension `create` with some changes to the CLI context helpers.
No longer removing the `yarn.lock` file.
