### PR TITLE
Updating ExtensionProject

### DIFF
--- a/lib/project_types/extension/commands/create.rb
+++ b/lib/project_types/extension/commands/create.rb
@@ -17,6 +17,7 @@ module Extension
             context: @ctx,
             api_key: form.app.api_key,
             api_secret: form.app.secret,
+            title: form.name,
             type: form.type.identifier
           )
 

--- a/lib/project_types/extension/extension_project.rb
+++ b/lib/project_types/extension/extension_project.rb
@@ -9,6 +9,7 @@ module Extension
 
     REGISTRATION_ID_KEY = 'EXTENSION_ID'
     EXTENSION_TYPE_KEY = 'EXTENSION_TYPE'
+    TITLE_KEY = 'EXTENSION_TITLE'
 
     def_delegators :project, :env, :directory, :config
 
@@ -19,17 +20,26 @@ module Extension
         ExtensionProject.new(project: ShopifyCli::Project.current)
       end
 
-      def write_project_files(context:, api_key:, api_secret:, type:)
-        ShopifyCli::Project.write(context, :extension)
-
+      def write_project_files(context:, api_key:, api_secret:, title:, type:)
+        ShopifyCli::Project.write(context, :extension, EXTENSION_TYPE_KEY => type)
         ShopifyCli::Resources::EnvFile.new(
           api_key: api_key,
           secret: api_secret,
-          extra: {
-            ExtensionProject::EXTENSION_TYPE_KEY => type
-          }
+          extra: { TITLE_KEY => title }.compact
         ).write(context)
       end
+    end
+
+    def app
+      Models::App.new(api_key: env['api_key'], secret: env['secret'])
+    end
+
+    def title
+      get_extra_field(TITLE_KEY)
+    end
+
+    def extension_type
+      Models::Type.load_type(config[EXTENSION_TYPE_KEY])
     end
 
     def registration_id?
@@ -37,16 +47,21 @@ module Extension
     end
 
     def registration_id
-      env[:extra][REGISTRATION_ID_KEY].to_i
+      get_extra_field(REGISTRATION_ID_KEY).to_i
     end
 
     def set_registration_id(context, new_registration_id)
       return if registration_id == new_registration_id
-      env.update(context, :extra, env[:extra].merge(REGISTRATION_ID_KEY => new_registration_id))
+
+      updated_extra = env[:extra].merge(REGISTRATION_ID_KEY => new_registration_id)
+      env.update(context, :extra, updated_extra)
     end
 
-    def extension_type
-      Models::Type.load_type(env[:extra][EXTENSION_TYPE_KEY])
+    private
+
+    def get_extra_field(key)
+      extra = env[:extra]
+      extra[key] unless extra.nil?
     end
   end
 end

--- a/test/project_types/extension/extension_project_test.rb
+++ b/test/project_types/extension/extension_project_test.rb
@@ -19,17 +19,33 @@ module Extension
         context: @new_context,
         api_key: 'test_key',
         api_secret: 'test_secret',
+        title: 'Registration Title',
         type: @type.identifier
       )
 
       assert File.exists?('.env')
       assert File.exists?('.shopify-cli.yml')
       assert_equal :extension, ShopifyCli::Project.current_project_type
+    end
 
-      project = ExtensionProject.current
-      assert_equal 'test_key', project.env['api_key']
-      assert_equal 'test_secret', project.env['secret']
-      assert_equal @type.identifier, project.extension_type.identifier
+    def test_can_access_app_specific_values_as_an_app
+      assert_kind_of Models::App, @project.app
+      assert_equal @api_key, @project.app.api_key
+      assert_equal @api_secret, @project.app.secret
+    end
+
+    def test_title_returns_the_title
+      assert_equal @title, @project.title
+    end
+
+    def test_title_returns_nil_if_title_is_missing
+      setup_temp_project(title: nil)
+      assert_nil ExtensionProject.current.title
+    end
+
+    def test_extension_type_returns_the_set_type_as_a_type_instance
+      assert_kind_of Models::Type, @project.extension_type
+      assert_equal @type.identifier, @project.extension_type.identifier
     end
 
     def test_can_write_and_read_registration_id_values
@@ -37,10 +53,6 @@ module Extension
       @project.set_registration_id(@context, 42)
 
       assert_equal 42, @project.registration_id
-    end
-
-    def test_extension_type_returns_a_type_instance
-      assert_kind_of Models::Type, @project.extension_type
     end
 
     def test_detects_if_registration_id_is_missing_or_invalid

--- a/test/project_types/extension/extension_test_helpers/temp_project_setup.rb
+++ b/test/project_types/extension/extension_test_helpers/temp_project_setup.rb
@@ -5,10 +5,11 @@ module Extension
     module TempProjectSetup
       include ExtensionTestHelpers::TestExtensionSetup
 
-      def setup_temp_project(api_key: 'TEST_KEY', api_secret: 'TEST_SECRET', type: @test_extension_type)
+      def setup_temp_project(api_key: 'TEST_KEY', api_secret: 'TEST_SECRET', title: 'Test', type: @test_extension_type)
         @context = TestHelpers::FakeContext.new(root: Dir.mktmpdir)
         @api_key = api_key
         @api_secret = api_secret
+        @title = title
         @type = type
 
         FileUtils.cd(@context.root)
@@ -16,6 +17,7 @@ module Extension
           context: @context,
           api_key: @api_key,
           api_secret: @api_secret,
+          title: @title,
           type: @type.identifier
         )
 


### PR DESCRIPTION
### WHY are these changes introduced?
Part of: https://github.com/Shopify/app-extension-libs/issues/299

After discussions with the CLI team they informed us that the `.shopify-cli.yml` file is meant for identifiers that relate to the operation of the CLI. All other values should go in the `.env` file. This PR moves our `type` storage into the `.shopify-cli.yml` file.
This PR also starts storing `title` within the `.env` file.

### WHAT is this pull request doing?
Adds `title` to the `.env` file.
Moved `type` to the `.shopify-cli.yml` file