### PR TITLE
Moving the last of the content strings to a common location

### DIFF
--- a/lib/project_types/extension/commands/pack.rb
+++ b/lib/project_types/extension/commands/pack.rb
@@ -9,11 +9,9 @@ module Extension
       YARN_BUILD_COMMAND = %w(yarn build)
       NPM_BUILD_COMMAND = %w(npm run-script build)
 
-      BUILD_FAILURE_MESSAGE = 'Failed to pack extension code for deployment.'
-
       def call(args, command_name)
         CLI::UI::Frame.open(frame_title) do
-          @ctx.abort(BUILD_FAILURE_MESSAGE) unless build.success?
+          @ctx.abort(Content::Pack::BUILD_FAILURE_MESSAGE) unless build.success?
         end
       end
 
@@ -27,7 +25,7 @@ module Extension
       private
 
       def frame_title
-        "Packing extension with: #{yarn_available? ? 'yarn' : 'npm'}..."
+        Content::Pack::FRAME_TITLE % (yarn_available? ? 'yarn' : 'npm')
       end
 
       def yarn_available?

--- a/lib/project_types/extension/commands/serve.rb
+++ b/lib/project_types/extension/commands/serve.rb
@@ -8,11 +8,11 @@ module Extension
       YARN_SERVE_COMMAND = %w(yarn server)
       NPM_SERVE_COMMAND = %w(npm run-script server)
 
-      SERVE_FAILURE_MESSAGE = 'Failed to run extension code for testing.'
+
 
       def call(args, command_name)
-        CLI::UI::Frame.open('Running your extension') do
-          @ctx.abort(SERVE_FAILURE_MESSAGE) unless serve.success?
+        CLI::UI::Frame.open(Content::Pack::FRAME_TITLE) do
+          @ctx.abort(Content::Serve::SERVE_FAILURE_MESSAGE) unless serve.success?
         end
       end
 

--- a/lib/project_types/extension/content.rb
+++ b/lib/project_types/extension/content.rb
@@ -14,6 +14,12 @@ module Extension
       LEARN_MORE = 'Learn more about building %s extensions at <shopify.dev>'
     end
 
+    module Pack
+      FRAME_TITLE = "Packing extension with: %s..."
+
+      BUILD_FAILURE_MESSAGE = 'Failed to pack extension code for deployment.'
+    end
+
     module Push
       FRAME_TITLE = 'Pushing your extension to Shopify'
       WAITING_TEXT = 'Pushing to Shopify...'
@@ -24,6 +30,12 @@ module Extension
 
       SUCCESS_CONFIRMATION = '{{v}} Extension has been pushed to a draft.'
       SUCCESS_INFO = '{{*}} Visit the Partner\'s Dashboard to create and publish versions.'
+    end
+
+    module Serve
+      FRAME_TITLE = 'Running your extension'
+
+      SERVE_FAILURE_MESSAGE = 'Failed to run extension code for testing.'
     end
   end
 end

--- a/test/project_types/extension/commands/pack_test.rb
+++ b/test/project_types/extension/commands/pack_test.rb
@@ -48,7 +48,7 @@ module Extension
       def test_aborts_and_informs_the_user_when_build_fails
         Pack.any_instance.stubs(:yarn_available?).returns(true)
         @context.expects(:system).with(*Pack::YARN_BUILD_COMMAND).returns(FakeProcessStatus.new(false))
-        @context.expects(:abort).with(Pack::BUILD_FAILURE_MESSAGE)
+        @context.expects(:abort).with(Content::Pack::BUILD_FAILURE_MESSAGE)
 
         run_cmd('pack')
       end

--- a/test/project_types/extension/commands/serve_test.rb
+++ b/test/project_types/extension/commands/serve_test.rb
@@ -44,7 +44,7 @@ module Extension
       def test_aborts_and_informs_the_user_when_serve_fails
         Serve.any_instance.stubs(:yarn_available?).returns(true)
         @context.expects(:system).with(*Serve::YARN_SERVE_COMMAND).returns(FakeProcessStatus.new(false))
-        @context.expects(:abort).with(Serve::SERVE_FAILURE_MESSAGE)
+        @context.expects(:abort).with(Content::Serve::SERVE_FAILURE_MESSAGE)
 
         run_cmd('serve')
       end


### PR DESCRIPTION
### WHY are these changes introduced?
Closes: https://github.com/Shopify/app-extension-libs/issues/414

This is the final few strings that should be remaining outside of the new `Content` module.

### WHAT is this pull request doing?
Moved the `serve` and `pack` commands into the `Content` module.
