### PR TITLE
Adding parsing of Validation Errors

### DIFF
--- a/lib/graphql/extension_create.graphql
+++ b/lib/graphql/extension_create.graphql
@@ -7,6 +7,10 @@ mutation ExtensionCreate($api_key: String!, $type: ExtensionType!, $title: Strin
       draftVersion {
         registrationId
         lastUserInteractionAt
+        validationErrors {
+          field
+          message
+        }
       }
     }
     userErrors {

--- a/lib/graphql/extension_update_draft.graphql
+++ b/lib/graphql/extension_update_draft.graphql
@@ -5,6 +5,10 @@ mutation ExtensionUpdateDraft($api_key: String!, $registration_id: ID!, $config:
       context
       lastUserInteractionAt
       location
+      validationErrors {
+        field
+        message
+      }
     }
     userErrors {
       field

--- a/lib/project_types/extension/cli.rb
+++ b/lib/project_types/extension/cli.rb
@@ -32,6 +32,12 @@ module Extension
     autoload :GetApps, Project.project_filepath('tasks/get_apps')
     autoload :CreateExtension, Project.project_filepath('tasks/create_extension')
     autoload :UpdateDraft, Project.project_filepath('tasks/update_draft')
+
+    module Converters
+      autoload :RegistrationConverter, Project.project_filepath('tasks/converters/registration_converter')
+      autoload :VersionConverter, Project.project_filepath('tasks/converters/version_converter')
+      autoload :ValidationErrorConverter, Project.project_filepath('tasks/converters/validation_error_converter')
+    end
   end
 
   module Forms
@@ -49,6 +55,7 @@ module Extension
     autoload :Registration, Project.project_filepath('models/registration')
     autoload :Version, Project.project_filepath('models/version')
     autoload :Type, Project.project_filepath('models/type')
+    autoload :ValidationError, Project.project_filepath('models/validation_error')
 
     class << self
       Models::Type.load_all

--- a/lib/project_types/extension/messages/messages.rb
+++ b/lib/project_types/extension/messages/messages.rb
@@ -58,6 +58,11 @@ module Extension
           }
         },
       },
+      tasks: {
+        errors: {
+          parse_error: 'Unable to parse response from Partners Dashboard.'
+        }
+      },
       errors: {
         unknown_type: 'Unknown extension type %s'
       }

--- a/lib/project_types/extension/models/validation_error.rb
+++ b/lib/project_types/extension/models/validation_error.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Extension
+  module Models
+    class ValidationError
+      include SmartProperties
+
+      IS_VALIDATION_ERROR_LIST = -> (errors) { errors.is_a?(Array) && errors.all?(IS_VALIDATION_ERROR) }
+      IS_VALIDATION_ERROR = -> (error) { error.is_a?(ValidationError) }
+
+      property! :field, accepts: -> (fields) { fields.all? { |field| field.is_a?(String) } }
+      property! :message, accepts: String
+    end
+  end
+end

--- a/lib/project_types/extension/models/version.rb
+++ b/lib/project_types/extension/models/version.rb
@@ -9,6 +9,7 @@ module Extension
       property! :last_user_interaction_at, accepts: Time
       property  :context, accepts: String
       property  :location, accepts: String
+      property :validation_errors, accepts: Models::ValidationError::IS_VALIDATION_ERROR_LIST, default: []
     end
   end
 end

--- a/lib/project_types/extension/tasks/converters/registration_converter.rb
+++ b/lib/project_types/extension/tasks/converters/registration_converter.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+require 'shopify_cli'
+
+module Extension
+  module Tasks
+    module Converters
+      module RegistrationConverter
+        ID_FIELD = 'id'
+        TYPE_FIELD = 'type'
+        TITLE_FIELD = 'title'
+        DRAFT_VERSION_FIELD = 'draftVersion'
+
+        def self.from_hash(context, hash)
+          context.abort(context.message('tasks.errors.parse_error')) if hash.nil?
+
+          Models::Registration.new(
+            id: hash[ID_FIELD].to_i,
+            type: hash[TYPE_FIELD],
+            title: hash[TITLE_FIELD],
+            draft_version: VersionConverter.from_hash(context, hash[DRAFT_VERSION_FIELD])
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/project_types/extension/tasks/converters/validation_error_converter.rb
+++ b/lib/project_types/extension/tasks/converters/validation_error_converter.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+require 'shopify_cli'
+
+module Extension
+  module Tasks
+    module Converters
+      module ValidationErrorConverter
+        FIELD_FIELD = 'field'
+        MESSAGE_FIELD = 'message'
+
+        def self.from_array(context, errors)
+          return [] if errors.nil?
+          context.abort(context.message('tasks.errors.parse_error')) unless errors.is_a?(Array)
+
+          errors.map do |error|
+            Models::ValidationError.new(
+              field: error[FIELD_FIELD],
+              message: error[MESSAGE_FIELD]
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/project_types/extension/tasks/converters/version_converter.rb
+++ b/lib/project_types/extension/tasks/converters/version_converter.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+require 'shopify_cli'
+
+module Extension
+  module Tasks
+    module Converters
+      module VersionConverter
+        REGISTRATION_ID_FIELD = 'registrationId'
+        CONTEXT_FIELD = 'context'
+        LAST_USER_INTERACTION_AT_FIELD = 'lastUserInteractionAt'
+        LOCATION_FIELD = 'location'
+        VALIDATION_ERRORS_FIELD = 'validationErrors'
+
+        def self.from_hash(context, hash)
+          context.abort(context.message('tasks.errors.parse_error')) if hash.nil?
+
+          Models::Version.new(
+            registration_id: hash[REGISTRATION_ID_FIELD].to_i,
+            context: hash[CONTEXT_FIELD],
+            last_user_interaction_at: Time.parse(hash[LAST_USER_INTERACTION_AT_FIELD]),
+            location: hash[LOCATION_FIELD],
+            validation_errors: Converters::ValidationErrorConverter.from_array(context, hash[VALIDATION_ERRORS_FIELD])
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/project_types/extension/tasks/create_extension.rb
+++ b/lib/project_types/extension/tasks/create_extension.rb
@@ -8,17 +8,8 @@ module Extension
 
       GRAPHQL_FILE = 'extension_create'
 
-      ID_FIELD = 'id'
-      TYPE_FIELD = 'type'
-      TITLE_FIELD = 'title'
-      DRAFT_VERSION_FIELD = 'draftVersion'
-      DRAFT_VERSION_REGISTRATION_ID_FIELD = %W(#{DRAFT_VERSION_FIELD} registrationId)
-      DRAFT_VERSION_LAST_USER_INTERACTION_AT_FIELD = %W(#{DRAFT_VERSION_FIELD} lastUserInteractionAt)
-
       RESPONSE_FIELD = %w(data extensionCreate)
       REGISTRATION_FIELD = 'extensionRegistration'
-
-      PARSE_ERROR = 'Unable to parse response from Partners Dashboard.'
 
       def call(context:, api_key:, type:, title:, config:, extension_context: nil)
         input = {
@@ -30,27 +21,10 @@ module Extension
         }
 
         response = ShopifyCli::PartnersAPI.query(context, GRAPHQL_FILE, input).dig(*RESPONSE_FIELD)
-        context.abort(PARSE_ERROR) if response.nil?
+        context.abort(context.message('tasks.errors.parse_error')) if response.nil?
 
         abort_if_user_errors(context, response)
-        response_to_registration(context, response)
-      end
-
-      private
-
-      def response_to_registration(context, response)
-        registration_hash = response.dig(REGISTRATION_FIELD)
-        context.abort(PARSE_ERROR) if registration_hash.nil?
-
-        Models::Registration.new(
-          id: registration_hash[ID_FIELD].to_i,
-          type: registration_hash[TYPE_FIELD],
-          title: registration_hash[TITLE_FIELD],
-          draft_version: Models::Version.new(
-            registration_id: registration_hash.dig(*DRAFT_VERSION_REGISTRATION_ID_FIELD).to_i,
-            last_user_interaction_at: Time.parse(registration_hash.dig(*DRAFT_VERSION_LAST_USER_INTERACTION_AT_FIELD)),
-          ),
-        )
+        Converters::RegistrationConverter.from_hash(context, response.dig(REGISTRATION_FIELD))
       end
     end
   end

--- a/test/project_types/extension/models/validation_error_test.rb
+++ b/test/project_types/extension/models/validation_error_test.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+module Extension
+  module Models
+    class ValidationErrorTest < MiniTest::Test
+      def setup
+        super
+        ShopifyCli::ProjectType.load_type(:extension)
+
+        @error = ValidationError.new(field: ['Hi'], message: 'message')
+      end
+
+      def test_field_only_accepts_an_array_of_strings
+        assert_raises(SmartProperties::InvalidValueError) { ValidationError.new(field: [1], message: '') }
+        assert_raises(SmartProperties::InvalidValueError) { ValidationError.new(field: [Object], message: '') }
+        assert_raises(SmartProperties::InvalidValueError) { ValidationError.new(field: ['field', 1], message: '') }
+
+        assert_nothing_raised { ValidationError.new(field: [], message: '') }
+        assert_nothing_raised { ValidationError.new(field: ['field'], message: '') }
+        assert_nothing_raised { ValidationError.new(field: %w(field1 field2), message: '') }
+      end
+
+      def test_is_validation_error_returns_true_if_an_object_is_a_validation_error
+        refute Models::ValidationError::IS_VALIDATION_ERROR.call(Object)
+        refute Models::ValidationError::IS_VALIDATION_ERROR.call(nil)
+        refute Models::ValidationError::IS_VALIDATION_ERROR.call([])
+
+        assert Models::ValidationError::IS_VALIDATION_ERROR.call(@error)
+      end
+
+      def test_is_validation_error_list_returns_true_if_an_object_is_a_list_of_validation_errors
+        refute Models::ValidationError::IS_VALIDATION_ERROR_LIST.call(nil)
+        refute Models::ValidationError::IS_VALIDATION_ERROR_LIST.call(Object)
+        refute Models::ValidationError::IS_VALIDATION_ERROR_LIST.call([Object])
+        refute Models::ValidationError::IS_VALIDATION_ERROR_LIST.call([@error, 1])
+
+        assert Models::ValidationError::IS_VALIDATION_ERROR_LIST.call([])
+        assert Models::ValidationError::IS_VALIDATION_ERROR_LIST.call([@error])
+        assert Models::ValidationError::IS_VALIDATION_ERROR_LIST.call(Array.new(2) { @error })
+      end
+    end
+  end
+end

--- a/test/project_types/extension/tasks/converters/registration_converter_test.rb
+++ b/test/project_types/extension/tasks/converters/registration_converter_test.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+require 'test_helper'
+require 'project_types/extension/extension_test_helpers'
+
+module Extension
+  module Tasks
+    module Converters
+      class RegistrationConverterTest < MiniTest::Test
+        include TestHelpers::FakeUI
+        include ExtensionTestHelpers::Messages
+
+        def setup
+          super
+          ShopifyCli::ProjectType.load_type(:extension)
+
+          @registration_id = 42
+          @fake_type = 'TEST_EXTENSION'
+          @fake_title = 'Fake Title'
+          @fake_extension_context = 'fake_context'
+          @last_user_interaction_at = Time.now.to_s
+        end
+
+        def test_from_hash_aborts_with_a_parse_error_if_the_hash_is_nil
+          io = capture_io_and_assert_raises(ShopifyCli::Abort) do
+            Converters::RegistrationConverter.from_hash(@context, nil)
+          end
+
+          assert_message_output(io: io, expected_content: @context.message('tasks.errors.parse_error'))
+        end
+
+        def test_from_hash_parses_registration_from_a_hash
+          hash = {
+            Converters::RegistrationConverter::ID_FIELD => @registration_id,
+            Converters::RegistrationConverter::TYPE_FIELD => @fake_type,
+            Converters::RegistrationConverter::TITLE_FIELD => @fake_title,
+            Converters::RegistrationConverter::DRAFT_VERSION_FIELD => {
+              Converters::VersionConverter::REGISTRATION_ID_FIELD => @registration_id,
+              Converters::VersionConverter::LAST_USER_INTERACTION_AT_FIELD => @last_user_interaction_at
+            }
+          }
+
+          parsed_registration = Converters::RegistrationConverter.from_hash(@context, hash)
+
+          assert_kind_of Models::Registration, parsed_registration
+          assert_equal @registration_id, parsed_registration.id
+          assert_equal @fake_type, parsed_registration.type
+          assert_equal @fake_title, parsed_registration.title
+          assert_equal @registration_id, parsed_registration.draft_version.registration_id
+          assert_kind_of Time, parsed_registration.draft_version.last_user_interaction_at
+        end
+      end
+    end
+  end
+end

--- a/test/project_types/extension/tasks/converters/validation_error_converter_test.rb
+++ b/test/project_types/extension/tasks/converters/validation_error_converter_test.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+require 'test_helper'
+require 'project_types/extension/extension_test_helpers'
+
+module Extension
+  module Tasks
+    module Converters
+      class ValidationErrorConverterTest < MiniTest::Test
+        include TestHelpers::FakeUI
+        include ExtensionTestHelpers::Messages
+
+        def setup
+          super
+          ShopifyCli::ProjectType.load_type(:extension)
+        end
+
+        def test_from_hash_returns_empty_array_if_errors_are_nil
+          assert_equal [], ValidationErrorConverter.from_array(@context, nil)
+        end
+
+        def test_from_hash_aborts_with_parse_error_if_errors_are_not_an_array_and_not_nil
+          io = capture_io_and_assert_raises(ShopifyCli::Abort) do
+            ValidationErrorConverter.from_array(@context, Object)
+          end
+
+          assert_message_output(io: io, expected_content: [
+            @context.message('tasks.errors.parse_error')
+          ])
+        end
+
+        def test_from_hash_returns_parsed_validation_errors_if_valid
+          fields = %w(config name)
+          message = 'error message'
+
+          errors = [{ 'field' => fields, 'message' => message }]
+          parsed_validation_errors = ValidationErrorConverter.from_array(@context, errors)
+
+          assert_equal 1, parsed_validation_errors.count
+          assert_equal fields, parsed_validation_errors.first.field
+          assert_equal message, parsed_validation_errors.first.message
+        end
+
+        def test_from_hash_returns_all_parsed_validation_errors_if_valid
+          message = 'error message'
+          message2 = 'error message 2'
+
+          errors = [
+            { 'field' => %w(field1), 'message' => message },
+            { 'field' => %w(config name), 'message' => message2 }
+          ]
+          parsed_validation_messages = ValidationErrorConverter.from_array(@context, errors).map(&:message)
+
+          assert_equal [message, message2], parsed_validation_messages
+        end
+      end
+    end
+  end
+end

--- a/test/project_types/extension/tasks/converters/version_converter_test.rb
+++ b/test/project_types/extension/tasks/converters/version_converter_test.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+require 'test_helper'
+require 'project_types/extension/extension_test_helpers'
+
+module Extension
+  module Tasks
+    module Converters
+      class VersionConverterTest < MiniTest::Test
+        include TestHelpers::FakeUI
+        include ExtensionTestHelpers::Messages
+
+        def setup
+          super
+          ShopifyCli::ProjectType.load_type(:extension)
+
+          @api_key = 'FAKE_API_KEY'
+          @registration_id = 42
+          @config = { }
+          @extension_context = 'fake#context'
+          @location = 'https://www.fakeurl.com'
+          @last_user_interaction_at = Time.now.to_s
+        end
+
+        def test_from_hash_aborts_with_a_parse_error_if_the_hash_is_nil
+          io = capture_io_and_assert_raises(ShopifyCli::Abort) do
+            Converters::VersionConverter.from_hash(@context, nil)
+          end
+
+          assert_message_output(io: io, expected_content: @context.message('tasks.errors.parse_error'))
+        end
+
+        def test_from_hash_parses_a_version_from_a_hash
+          hash = {
+            Converters::VersionConverter::REGISTRATION_ID_FIELD => @registration_id,
+            Converters::VersionConverter::LAST_USER_INTERACTION_AT_FIELD => @last_user_interaction_at,
+            Converters::VersionConverter::CONTEXT_FIELD => @extension_context,
+            Converters::VersionConverter::LOCATION_FIELD => @location,
+            Converters::VersionConverter::VALIDATION_ERRORS_FIELD => []
+          }
+
+          parsed_version = Tasks::Converters::VersionConverter.from_hash(@context, hash)
+
+          assert_kind_of Models::Version, parsed_version
+          assert_equal @registration_id, parsed_version.registration_id
+          assert_kind_of Time, parsed_version.last_user_interaction_at
+          assert_equal @extension_context, parsed_version.context
+          assert_equal @location, parsed_version.location
+          assert_equal [], parsed_version.validation_errors
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### WHY are these changes introduced?
Part of: https://github.com/Shopify/app-extension-libs/issues/302

Need to start handling Validation Errors on the CLI. Currently there are rare validation errors but the expectation will be that these expand

### WHAT is this pull request doing?
Requesting and parsing validation errors. Per the issue, the next PR will take the validation errors and display them correctly based on UX designs.

- Pulled all parsing from `CreateExtension` and `UpdateDraft` tasks to `Converters`
- Created `VersionConverter` and `RegistrationConverter`
- Created `ValidationError` model
- Created `ValidationErrorConverter`
- Updated GraphQL files to request `validationErrors` with `Version`
- Updated `Version` model to hold `validation_errors`
- Updated `VersionConverter` to parse new `validation_errors`

### Test Run
![Screen Shot 2020-06-12 at 9 55 26 AM](https://user-images.githubusercontent.com/42751082/84510304-f55df680-ac92-11ea-84ae-c768ea110cd3.png)
