### PR TITLE
Fixing an error with app loading

### DIFF
--- a/lib/project_types/extension/tasks/get_apps.rb
+++ b/lib/project_types/extension/tasks/get_apps.rb
@@ -13,12 +13,13 @@ module Extension
 
       def apps_from_organizations(organizations)
         organizations.flat_map do |organization|
-          return [] unless organization.key?('apps') && organization['apps'].any?
           apps_owned_by_organization(organization)
         end
       end
 
       def apps_owned_by_organization(organization)
+        return [] unless organization.key?('apps') && organization['apps'].any?
+
         organization['apps'].map do |app|
           Models::App.new(
             api_key: app['apiKey'],

--- a/test/project_types/extension/commands/create_test.rb
+++ b/test/project_types/extension/commands/create_test.rb
@@ -25,7 +25,9 @@ module Extension
 
         JsDeps.expects(:install).add_side_effect(CreateDummyLockfile.new)
         ShopifyCli::Core::Finalize.expects(:request_cd).with('myext')
-        stub_get_organizations
+        stub_get_organizations([
+          organization(name: "Organization One", apps: [Models::App.new(api_key: '1234', secret: '4567')])
+        ])
 
         io = capture_io do
           run_cmd("create extension --name=#{name} --type=#{@test_extension_type.identifier} --api-key=1234")

--- a/test/project_types/extension/extension_test_helpers/stubs/get_organizations.rb
+++ b/test/project_types/extension/extension_test_helpers/stubs/get_organizations.rb
@@ -6,74 +6,56 @@ module Extension
       module GetOrganizations
         include TestHelpers::Partners
 
-        def stub_get_organizations(organization_name: 'one', app_title: 'App', api_key: '1234', api_secret: '5678')
-          stub_partner_req(
-            'all_orgs_with_apps',
-            resp: {
-              data: {
-                organizations: {
-                  nodes: [
-                    {
-                      'id': rand(9999),
-                      'businessName': organization_name,
-                      'stores': {
-                        'nodes': [
-                          { 'shopDomain': 'store.myshopify.com' },
-                        ],
-                      },
-                      'apps': {
-                        nodes: [{
-                                  id: rand(9999),
-                                  title: app_title,
-                                  'apiKey': api_key,
-                                  'apiSecretKeys': [{
-                                                      'secret': api_secret,
-                                                    }],
-                                }],
-                      },
-                    },
-                  ],
-                },
-              },
-            },
-          )
+        def organization(name:, apps:)
+          {
+            name: name,
+            apps: apps
+          }
         end
 
-        def stub_no_organizations
+        def stub_get_organizations(organizations)
           stub_partner_req(
             'all_orgs_with_apps',
             resp: {
               data: {
                 organizations: {
-                  nodes: []
-                },
-              },
-            },
-          )
-        end
-
-        def stub_no_apps(organization_name)
-          stub_partner_req(
-            'all_orgs_with_apps',
-            resp: {
-              data: {
-                organizations: {
-                  nodes: [
-                    {
-                      'id': rand(9999),
-                      'businessName': organization_name,
-                      'stores': {
-                        'nodes': [
-                          { 'shopDomain': 'store.myshopify.com' },
-                        ],
-                      },
-                      'apps': { nodes: [] },
-                    },
-                  ],
+                  nodes: create_organizations_json(organizations)
                 },
               },
             },
             )
+        end
+
+        def create_organizations_json(organizations)
+          organizations.map do |organization|
+            create_organization_json(name: organization[:name], apps: organization[:apps])
+          end
+        end
+
+        def create_organization_json(name:, apps:)
+          {
+            'id': rand(9999),
+            'businessName': name,
+            'stores': {
+              'nodes': [
+                { 'shopDomain': 'store.myshopify.com' },
+              ],
+            },
+            'apps': {
+              nodes: create_apps_json(apps),
+            }
+          }
+        end
+
+        def create_apps_json(apps)
+          apps.map do |app|
+            {
+              id: rand(9999),
+              title: app.title,
+              'apiKey': app.api_key,
+              'apiSecretKeys': [{'secret': app.secret, }],
+            }
+          end
         end
       end
     end


### PR DESCRIPTION
### WHY are these changes introduced?
There was a bug withing the `GetApps` Task. There was an early escape from the `apps_from_organizations` loop that would return no apps if any of the organizations the Partner was a part of had no apps. 

This fix was to move the offending `return` statement into the `apps_owned_by_organization` method which works only on the single organization and therefore could escape if no apps were present without causing an issue for the rest of the data.

### WHAT is this pull request doing?
- Fix the bug outlined above
- Clean up the `get_organizations` stub since better stubbing was needed for this case
- Create a test for this test case to ensure we don't readd the bug
