### PR TITLE
Integrating extension title with CLI

### DIFF
--- a/lib/project_types/extension/commands/push.rb
+++ b/lib/project_types/extension/commands/push.rb
@@ -12,7 +12,7 @@ module Extension
         CLI::UI::Frame.open(Content::Push::FRAME_TITLE) do
           @project.registration_id? ? update_draft : confirm_before_creating_extension
 
-          @ctx.puts(Content::Push::SUCCESS_CONFIRMATION)
+          @ctx.puts(Content::Push::SUCCESS_CONFIRMATION % @project.title)
           @ctx.puts(Content::Push::SUCCESS_INFO)
         end
       end
@@ -37,7 +37,7 @@ module Extension
 
         Tasks::UpdateDraft.call(
           context: @ctx,
-          api_key: @project.env['api_key'],
+          api_key: @project.app.api_key,
           registration_id: @project.registration_id,
           config: @project.extension_type.config(@ctx),
           extension_context: @project.extension_type.extension_context(@ctx)
@@ -55,9 +55,9 @@ module Extension
 
         registration = Tasks::CreateExtension.call(
           context: @ctx,
-          api_key: @project.env['api_key'],
+          api_key: @project.app.api_key,
           type: @project.extension_type.identifier,
-          title: 'Testing the CLI',
+          title: @project.title,
           config: @project.extension_type.config(@ctx),
           extension_context: @project.extension_type.extension_context(@ctx)
         )

--- a/lib/project_types/extension/content.rb
+++ b/lib/project_types/extension/content.rb
@@ -31,7 +31,7 @@ module Extension
       CREATE_CONFIRM_QUESTION = 'This is not reversible (y/n)'
       CREATE_ABORT = 'Pushing extension aborted by user.'
 
-      SUCCESS_CONFIRMATION = '{{v}} Extension has been pushed to a draft.'
+      SUCCESS_CONFIRMATION = '{{v}} %s has been pushed to a draft.'
       SUCCESS_INFO = '{{*}} Visit the Partner\'s Dashboard to create and publish versions.'
     end
 

--- a/lib/project_types/extension/extension_project.rb
+++ b/lib/project_types/extension/extension_project.rb
@@ -51,6 +51,7 @@ module Extension
     end
 
     def set_registration_id(context, new_registration_id)
+      return if new_registration_id.nil?
       return if registration_id == new_registration_id
 
       updated_extra = env[:extra].merge(REGISTRATION_ID_KEY => new_registration_id)
@@ -60,8 +61,8 @@ module Extension
     private
 
     def get_extra_field(key)
-      extra = env[:extra]
-      extra[key] unless extra.nil?
+      extra = env[:extra] || {}
+      extra[key]
     end
   end
 end

--- a/test/project_types/extension/commands/push_test.rb
+++ b/test/project_types/extension/commands/push_test.rb
@@ -17,7 +17,7 @@ module Extension
         @registration = Models::Registration.new(
           id: 42,
           type: @type.identifier,
-          title: 'Fake Registration'
+          title: @title
         )
       end
 
@@ -57,7 +57,7 @@ module Extension
             context: @context,
             api_key: @api_key,
             type: @type.identifier,
-            title: 'Testing the CLI',
+            title: @title,
             config: @type.config(@context),
             extension_context: @type.extension_context(@context)
           )
@@ -68,7 +68,7 @@ module Extension
         assert_equal @registration.id, @project.registration_id
         confirm_content_output(io: io, expected_content: [
           Content::Push::WAITING_TEXT,
-          Content::Push::SUCCESS_CONFIRMATION,
+          Content::Push::SUCCESS_CONFIRMATION % @title,
           Content::Push::SUCCESS_INFO
         ])
       end
@@ -90,7 +90,7 @@ module Extension
 
         confirm_content_output(io: io, expected_content: [
           Content::Push::WAITING_TEXT,
-          Content::Push::SUCCESS_CONFIRMATION,
+          Content::Push::SUCCESS_CONFIRMATION % @title,
           Content::Push::SUCCESS_INFO
         ])
       end

--- a/test/project_types/extension/extension_project_test.rb
+++ b/test/project_types/extension/extension_project_test.rb
@@ -77,6 +77,12 @@ module Extension
       @project.set_registration_id(@context, 42)
     end
 
+    def test_set_registration_id_does_not_write_the_env_file_if_registration_id_empty
+      ShopifyCli::Resources::EnvFile.any_instance.expects(:write).never
+
+      @project.set_registration_id(@context, nil)
+    end
+
     def test_delegate_standard_project_methods_to_internal_project_instance
       @project.project.expects(:env).once
       @project.env


### PR DESCRIPTION
### WHY are these changes introduced?
Closes: https://github.com/Shopify/app-extension-libs/issues/299
ExtensionProject was upgraded to include `title` and move around `type` in the PR here: https://github.com/Shopify/shopify-app-cli-extensions/pull/23

Now that it has been merged we want to start using title properly in all the needed locations. `create` already had access to the form which had `title` but `push` was missing it.

### WHAT is this pull request doing?
- Updates to use `title` where applicable
- Includes fixes from https://github.com/Shopify/shopify-app-cli-extensions/pull/23 because it was rushed out for demo
