### PR TITLE
Validate and re-prompt for name on extension create form

### DIFF
--- a/lib/project_types/extension/content.rb
+++ b/lib/project_types/extension/content.rb
@@ -1,7 +1,8 @@
 module Extension
   module Content
     module Create
-      ASK_NAME = 'Extension name (40 characters):'
+      ASK_NAME = 'Extension name'
+      INVALID_NAME = "Extension name must be under %s characters"
 
       ASK_TYPE = 'What type of extension would you like to create?'
       INVALID_TYPE = 'Invalid extension type.'

--- a/lib/project_types/extension/forms/create.rb
+++ b/lib/project_types/extension/forms/create.rb
@@ -24,8 +24,12 @@ module Extension
       private
 
       def ask_name
-        return name unless name.nil? || name.strip.empty?
-        CLI::UI::Prompt.ask(Content::Create::ASK_NAME)
+        ask_with_reprompt(
+          initial_value: self.name,
+          break_condition: -> (current_name) { Models::Registration.valid_title?(current_name) },
+          prompt_message: Content::Create::ASK_NAME,
+          reprompt_message: Content::Create::INVALID_NAME % Models::Registration::MAX_TITLE_LENGTH
+        )
       end
 
       def ask_type
@@ -54,6 +58,20 @@ module Extension
             end
           end
         end
+      end
+
+      private
+
+      def ask_with_reprompt(initial_value:, break_condition:, prompt_message:, reprompt_message:)
+        value = initial_value
+        reprompt = false
+
+        while !break_condition.call(value) do
+          ctx.puts(reprompt_message) if reprompt
+          value = CLI::UI::Prompt.ask(prompt_message)&.strip
+          reprompt = true
+        end
+        value
       end
     end
   end

--- a/lib/project_types/extension/models/registration.rb
+++ b/lib/project_types/extension/models/registration.rb
@@ -3,11 +3,16 @@
 module Extension
   module Models
     class Registration
+      MAX_TITLE_LENGTH = 50
       include SmartProperties
 
       property! :id, accepts: Integer
       property! :type, accepts: String
       property! :title, accepts: String
+
+      def self.valid_title?(title)
+        !title.nil? && !title.strip.empty? && title.length <= MAX_TITLE_LENGTH
+      end
     end
   end
 end

--- a/test/project_types/extension/models/registration_test.rb
+++ b/test/project_types/extension/models/registration_test.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+module Extension
+  module Models
+    class RegistrationTest < MiniTest::Test
+      def test_valid_title_returns_true_for_valid_title
+        assert Models::Registration.valid_title?('A title')
+      end
+
+      def test_valid_title_returns_false_for_missing_title
+        refute Models::Registration.valid_title?(nil)
+        refute Models::Registration.valid_title?('')
+        refute Models::Registration.valid_title?('  ')
+      end
+
+      def test_valid_title_returns_false_when_title_too_long
+        refute Models::Registration.valid_title?(
+          Array.new(Registration::MAX_TITLE_LENGTH + 1, 'a').join
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
Part of: https://github.com/Shopify/app-extension-libs/issues/413

A PR to align on how we handle explicit nils will follow, if needed

Summary
- according to UX plan, we should validate the given values to the create form, and reprompt when necessary
- this PR adds validation and re-prompting for 'name'
- I moved the re-prompt logic out to a method, but it would be cool to move this out to a more generic module so we could re-use the logic. Didn't seem strictly necessary here, and we are on a timeline, so I opted not to do that here. Once we get a second case where we require re-prompting we can revisit if people like the idea

Not in this PR, but in the ticket
- validation for type and apiKey/app seems unnecessary as they are chosen from a list of options and both have mapped invalid input strings which are surfaced if given as arguments
- copy alignment. That is happening in it's own PR when finalized.
- how do we deal with explicit nils -- should we show the error messaging or not when an argument is explicitly given as blank/nil? This was not defined in the doc so I did not add it here. I'll make a follow-up PR (if needed) to deal with that.

Successful local test run
![Screen Shot 2020-05-05 at 10 32 39 AM](https://user-images.githubusercontent.com/4079241/81078150-d7df8500-8ebb-11ea-8a45-8ca71e376144.png)

