### PR TITLE
Unhide serve command

### DIFF
--- a/lib/project_types/extension/commands/serve.rb
+++ b/lib/project_types/extension/commands/serve.rb
@@ -15,7 +15,7 @@ module Extension
 
       def self.help
         <<~HELP
-          Serve your extension locally for testing.
+          Serve your extension in a local simulator for development.
             Usage: {{command:#{ShopifyCli::TOOL_NAME} serve}}
         HELP
       end

--- a/lib/project_types/extension/content.rb
+++ b/lib/project_types/extension/content.rb
@@ -33,7 +33,7 @@ module Extension
     end
 
     module Serve
-      FRAME_TITLE = 'Running your extension'
+      FRAME_TITLE = 'Serving extension...'
 
       SERVE_FAILURE_MESSAGE = 'Failed to run extension code for testing.'
     end


### PR DESCRIPTION
### WHY are these changes introduced?

Relates to  https://github.com/Shopify/app-extension-libs/issues/355

It looks like any further functional work for fetching the runtime initialization will be a front end task, and all that is needed on the backend (in this minimal implementation, at least) is to wrap yarn server.

### WHAT is this pull request doing?
Unhiding the command since we know for sure now that it will be needed.

This PR also updates to content strings to reflect [the latest](https://docs.google.com/document/d/1MFJ-V1zox8iWU2Wo8rR2LJmbcdkOYMICYvbK96aM--E/edit#). Note: this is not a final UX/Content pass.

Build passing:
![image](https://user-images.githubusercontent.com/3375286/81102967-5d742c80-8ede-11ea-97db-c5c55e585cfd.png)


