### PR TITLE
Prompt for api key if missing or invalid when creating extension

### DIFF
--- a/lib/project_types/extension/forms/create.rb
+++ b/lib/project_types/extension/forms/create.rb
@@ -48,19 +48,31 @@ module Extension
         ctx.abort(Content::Create::NO_APPS) if apps.empty?
 
         if !api_key.nil?
-          found_app = apps.find { |app| app.api_key == api_key }
-          ctx.abort(Content::Create::INVALID_API_KEY % api_key) if found_app.nil?
-          found_app
-        else
-          CLI::UI::Prompt.ask(Content::Create::ASK_APP) do |handler|
-            apps.each do |app|
-              handler.option("#{app.title} by #{app.business_name}") { app }
-            end
+          found_app = app_from_api_key(apps, api_key)
+
+          if found_app.nil?
+            ctx.puts(Content::Create::INVALID_API_KEY % api_key)
+          else
+            return found_app
           end
         end
+
+        ask_for_selection_from(apps)
       end
 
       private
+
+      def app_from_api_key(apps, api_key)
+        apps.find { |app| app.api_key == api_key }
+      end
+
+      def ask_for_selection_from(apps)
+        CLI::UI::Prompt.ask(Content::Create::ASK_APP) do |handler|
+          apps.each do |app|
+            handler.option("#{app.title} by #{app.business_name}") { app }
+          end
+        end
+      end
 
       def ask_with_reprompt(initial_value:, break_condition:, prompt_message:, reprompt_message:)
         value = initial_value

--- a/test/project_types/extension/forms/create_test.rb
+++ b/test/project_types/extension/forms/create_test.rb
@@ -7,6 +7,7 @@ module Extension
     class CreateTest < MiniTest::Test
       include TestHelpers::FakeUI
       include ExtensionTestHelpers::TestExtensionSetup
+      include ExtensionTestHelpers::Content
 
       def setup
         super
@@ -95,20 +96,18 @@ module Extension
         assert_equal form.app, @app
       end
 
-      def test_prompts_the_user_to_choose_an_app_to_associate_with_extension_if_no_app_is_provided
+      def test_prompts_the_user_to_choose_an_app_to_associate_with_extension_if_no_api_key_is_provided
         CLI::UI::Prompt.expects(:ask).with(Content::Create::ASK_APP)
-
-        capture_io do
-          ask(api_key: nil)
-        end
+        capture_io { ask(api_key: nil) }
       end
 
-      def test_fails_with_invalid_api_key_to_associate_with_extension
+      def test_prompts_the_user_to_choose_an_app_if_invalid_key_given
+        CLI::UI::Prompt.expects(:ask).with(Content::Create::ASK_APP)
         api_key = '00001'
 
         io = capture_io { ask(api_key: api_key) }
 
-        assert_match(Content::Create::INVALID_API_KEY % api_key, io.join)
+        confirm_content_output(io: io, expected_content: Content::Create::INVALID_API_KEY % api_key)
       end
 
       private


### PR DESCRIPTION
Closes: Shopify/app-extension-libs#413
Follows: https://github.com/Shopify/shopify-app-cli-extensions/pull/28

### Summary
- talked to UX and we want to prompt the user for a value when an invalid `api_key` is given as a command line argument, instead of aborting and logging an error to the console. Once you are prompted to choose, it shows you a list, so there is no need for re-prompt behaviour here.

Not in this PR
 - dealing with explicit nils. There seems to be no real good way to test the difference between a given nil and nil due to a missing argument. UX would like to see the invalid input errors for all 3 fields if they are given as command line arguments, but no value is passed. Right now, name does not act this way, type and api_key do. I'm adding this to the following ticket for now because it does not seem super high priority.  - https://github.com/Shopify/app-extension-libs/issues/412

Passing tests
![Screen Shot 2020-05-05 at 4 32 08 PM](https://user-images.githubusercontent.com/4079241/81115021-117eb300-8ef1-11ea-862b-aced9dae0d56.png)