### PR TITLE
Updating create process to initialize template

### DIFF
--- a/lib/project_types/extension/commands/create.rb
+++ b/lib/project_types/extension/commands/create.rb
@@ -11,7 +11,7 @@ module Extension
 
       def call(args, _)
         with_create_form(args) do |form|
-          build(form.directory_name)
+          form.type.create(form.directory_name, @ctx)
 
           ExtensionProject.write_project_files(
             context: @ctx,
@@ -21,8 +21,10 @@ module Extension
             type: form.type.identifier
           )
 
-          @ctx.puts('{{*}} ' + Content::Create::READY_TO_START % form.name)
-          @ctx.puts('{{*}} ' + Content::Create::LEARN_MORE % form.type.name)
+          ShopifyCli::Core::Finalize.request_cd(form.directory_name)
+
+          @ctx.puts(Content::Create::READY_TO_START % form.name)
+          @ctx.puts(Content::Create::LEARN_MORE % form.type.name)
         end
       end
 
@@ -44,20 +46,6 @@ module Extension
         return @ctx.puts(self.class.help) if form.nil?
 
         yield form
-      end
-
-      def build(name)
-        ShopifyCli::Git.clone('https://github.com/Shopify/shopify-app-extension-template.git', name, ctx: @ctx)
-        ShopifyCli::Core::Finalize.request_cd(name)
-        @ctx.root = File.join(@ctx.root, name)
-
-        begin
-          @ctx.rm_r('.git')
-        rescue Errno::ENOENT => e
-          @ctx.debug(e)
-        end
-
-        JsDeps.install(@ctx)
       end
     end
   end

--- a/lib/project_types/extension/content.rb
+++ b/lib/project_types/extension/content.rb
@@ -13,8 +13,10 @@ module Extension
       NO_APPS = 'You don’t have any apps. Learn more about building apps at <https://shopify.dev/concepts/apps> or try creating one using a new app using {{command:shopify create app}}.'
       INVALID_API_KEY = 'The API key %s does not match any of your apps.'
 
-      READY_TO_START = 'You\'re ready to start building %s! Try running `shopify serve` to start a local server.'
-      LEARN_MORE = 'Learn more about building %s extensions at <shopify.dev>'
+      SETUP_PROJECT_FRAME_TITLE = 'Initializing Project'
+
+      READY_TO_START = '{{*}} You\'re ready to start building %s! Try running `shopify serve` to start a local server.'
+      LEARN_MORE = '{{*}} Learn more about building %s extensions at <shopify.dev>'
     end
 
     module Pack
@@ -43,11 +45,13 @@ module Extension
 
     module Models
       TYPES = {
+        ARGO: {
+          missing_file_error: 'Could not find built extension file.',
+          script_prepare_error: 'An error occurred while attempting to prepare your script.'
+        },
         Extension::Models::Types::SubscriptionManagement::IDENTIFIER => {
           name: 'Subscription Management',
           tagline: '(limit 1 per app)',
-          missing_file_error: 'Could not find built extension file.',
-          script_prepare_error: 'An error occurred while attempting to prepare your script.'
         }
       }
     end

--- a/lib/project_types/extension/models/type.rb
+++ b/lib/project_types/extension/models/type.rb
@@ -49,6 +49,10 @@ module Extension
         raise NotImplementedError, "'#{__method__}' must be implemented for #{self.class}"
       end
 
+      def create(_directory_name, _context)
+        raise NotImplementedError, "'#{__method__}' must be implemented for #{self.class}"
+      end
+
       def extension_context(_context)
         nil
       end

--- a/lib/project_types/extension/models/types/argo.rb
+++ b/lib/project_types/extension/models/types/argo.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+require 'base64'
+
+module Extension
+  module Models
+    module Types
+      module Argo
+        GIT_TEMPLATE = 'https://github.com/Shopify/shopify-app-extension-template.git'.freeze
+        SCRIPT_PATH = %w(build main.js).freeze
+
+        GIT_DIRECTORY = '.git'.freeze
+        SCRIPTS_DIRECTORY = 'scripts'.freeze
+
+        YARN_INITIALIZE_COMMAND = %w(yarn generate).freeze
+        NPM_INITIALIZE_COMMAND = %w(npm run generate --).freeze
+        INITIALIZE_TYPE_PARAMETER = '--type=%s'.freeze
+
+        class << self
+          def create(directory_name, identifier, context)
+            clone_template(directory_name, context)
+            initialize_project(identifier, context)
+            cleanup(context)
+          end
+
+          def config(context)
+            filepath = File.join(context.root, SCRIPT_PATH)
+            context.abort(Content::Models::TYPES[:ARGO][:missing_file_error]) unless File.exists?(filepath)
+
+            begin
+              {
+                serialized_script: Base64.strict_encode64(File.open(filepath).read.chomp)
+              }
+            rescue Exception
+              context.abort(Content::Models::TYPES[:ARGO][:script_prepare_error])
+            end
+          end
+
+          def clone_template(directory_name, context)
+            ShopifyCli::Git.clone(GIT_TEMPLATE, directory_name, ctx: context)
+            context.root = File.join(context.root, directory_name)
+          end
+
+          def initialize_project(identifier, context)
+            JsDeps.install(context)
+
+            initialize_command = JsDeps.new(ctx: context).yarn? ? YARN_INITIALIZE_COMMAND : NPM_INITIALIZE_COMMAND
+            initialize_command = initialize_command + [INITIALIZE_TYPE_PARAMETER % identifier]
+
+            CLI::UI::Frame.open(Content::Create::SETUP_PROJECT_FRAME_TITLE) do
+              context.system(*initialize_command, chdir: context.root)
+            end
+          end
+
+          def cleanup(context)
+            begin
+              context.rm_r(GIT_DIRECTORY)
+              context.rm_r(SCRIPTS_DIRECTORY)
+            rescue Errno::ENOENT => e
+              context.debug(e)
+            end
+          end
+        end
+      end
+    end
+  end
+end
+

--- a/lib/project_types/extension/models/types/subscription_management.rb
+++ b/lib/project_types/extension/models/types/subscription_management.rb
@@ -6,19 +6,13 @@ module Extension
     module Types
       class SubscriptionManagement < Models::Type
         IDENTIFIER = 'SUBSCRIPTION_MANAGEMENT'
-        SCRIPT_PATH = %w(build main.js)
+
+        def create(directory_name, context)
+          Models::Types::Argo.create(directory_name, IDENTIFIER, context)
+        end
 
         def config(context)
-          filepath = File.join(context.root, SCRIPT_PATH)
-          context.abort(get_content(:missing_file_error)) unless File.exists?(filepath)
-
-          begin
-            {
-              serialized_script: Base64.strict_encode64(File.open(filepath).read.chomp)
-            }
-          rescue Exception
-            context.abort(get_content(:script_prepare_error))
-          end
+          Models::Types::Argo.config(context)
         end
       end
     end

--- a/test/project_types/extension/extension_test_helpers/content.rb
+++ b/test/project_types/extension/extension_test_helpers/content.rb
@@ -7,7 +7,7 @@ module Extension
         all_output = io.join
 
         Array(expected_content).each do |expected|
-          assert_match CLI::UI.fmt(expected), all_output
+          assert_includes all_output, CLI::UI.fmt(expected)
         end
       end
     end

--- a/test/project_types/extension/models/type_test.rb
+++ b/test/project_types/extension/models/type_test.rb
@@ -25,6 +25,7 @@ module Extension
 
       def test_raises_not_implemented_error_for_required_methods
         assert_raises(NotImplementedError) { Models::Type.new.config(@context) }
+        assert_raises(NotImplementedError) { Models::Type.new.create('name', @context) }
       end
 
       def test_valid_extension_contexts_returns_empty_array

--- a/test/project_types/extension/models/types/argo_test.rb
+++ b/test/project_types/extension/models/types/argo_test.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+require 'test_helper'
+require 'project_types/extension/extension_test_helpers'
+require 'base64'
+require 'pathname'
+
+module Extension
+  module Models
+    module Types
+      class ArgoTest < MiniTest::Test
+        include TestHelpers::FakeUI
+        include ExtensionTestHelpers::Stubs::ArgoScript
+
+        def setup
+          super
+          ShopifyCli::ProjectType.load_type(:extension)
+
+          @identifier = 'FAKE_ARGO_TYPE'
+          @directory = 'fake_directory'
+        end
+
+        def test_create_clones_repo_then_initializes_project_then_cleans_up
+          Argo.expects(:clone_template).with(@directory, @context).once
+          Argo.expects(:initialize_project).with(@identifier, @context).once
+          Argo.expects(:cleanup).with(@context).once
+
+          Argo.create(@directory, @identifier, @context)
+        end
+
+        def test_clone_template_clones_argo_template_git_repo_into_directory_and_updates_context_root
+          ShopifyCli::Git.expects(:clone).with(Argo::GIT_TEMPLATE, @directory, ctx: @context).once
+
+          Argo.clone_template(@directory, @context)
+
+          assert_equal @directory, Pathname(@context.root).each_filename.to_a.last
+        end
+
+        def test_initialize_project_installs_js_dependencies_and_runs_generate_script_with_npm
+          expected_npm_command = Argo::NPM_INITIALIZE_COMMAND + [Argo::INITIALIZE_TYPE_PARAMETER % @identifier]
+
+          JsDeps.expects(:install).once
+          JsDeps.any_instance.expects(:yarn?).returns(false).once
+          @context.expects(:system).with(*expected_npm_command, chdir: @context.root).once
+
+          Argo.initialize_project(@identifier, @context)
+        end
+
+        def test_initialize_project_installs_js_dependencies_and_runs_generate_script_with_yarn
+          expected_yarn_command = Argo::YARN_INITIALIZE_COMMAND + [Argo::INITIALIZE_TYPE_PARAMETER % @identifier]
+
+          JsDeps.expects(:install).once
+          JsDeps.any_instance.expects(:yarn?).returns(true).once
+          @context.expects(:system).with(*expected_yarn_command, chdir: @context.root).once
+
+          Argo.initialize_project(@identifier, @context)
+        end
+
+        def test_cleanup_removes_git_and_script_directories
+          @context.expects(:rm_r).with(Argo::GIT_DIRECTORY).once
+          @context.expects(:rm_r).with(Argo::SCRIPTS_DIRECTORY).once
+
+          Argo.cleanup(@context)
+        end
+
+        def test_config_aborts_with_error_if_script_file_doesnt_exist
+          error = assert_raises ShopifyCli::Abort do
+            Argo.config(@context)
+          end
+
+          assert error.message.include?(Content::Models::TYPES[:ARGO][:missing_file_error])
+        end
+
+        def test_config_aborts_with_error_if_script_serialization_fails
+          File.stubs(:exists?).returns(true)
+          Base64.stubs(:strict_encode64).raises(IOError)
+
+          error = assert_raises(ShopifyCli::Abort) { Argo.config(@context) }
+          assert error.message.include?(Content::Models::TYPES[:ARGO][:script_prepare_error])
+        end
+
+        def test_config_aborts_with_error_if_file_read_fails
+          File.stubs(:exists?).returns(true)
+          File.any_instance.stubs(:read).raises(IOError)
+
+          error = assert_raises(ShopifyCli::Abort) { Argo.config(@context) }
+          assert error.message.include?(Content::Models::TYPES[:ARGO][:script_prepare_error])
+        end
+
+        def test_config_encodes_script_into_context_if_it_exists
+          with_stubbed_script(@context, Argo::SCRIPT_PATH) do
+            config = Argo.config(@context)
+
+            assert_equal [:serialized_script], config.keys
+            assert_equal Base64.strict_encode64(TEMPLATE_SCRIPT.chomp), config[:serialized_script]
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### WHY are these changes introduced?
Closes: https://github.com/Shopify/shopify-app-cli-extensions/issues/31

This is the PR started during the mob pair.

The Argo template repository is no longer a static template. It now requires us to run a generation script that will generate the source files that Partners will work with. We needed to upgrade the `create` process to handle this new initialization step. 

As part of this work I have isolated the actual creation step to be specific to Argo. Now that we have the `type` system built into the CLI it makes sense that creation is type-specific the same as config creation is.

### WHAT is this pull request doing?
- Added the `initialize` step to create
- Moved creation to be `type` specific 
- Made a reusable `Argo` module for running standard `Argo` commands (`create`, `config`)
- Cleaned up the `create` command tests as they are streamlined
- Isolated `Argo` tests to the `Argo` module.
