### PR TITLE
Adding the Register command

### DIFF
--- a/lib/project_types/extension/cli.rb
+++ b/lib/project_types/extension/cli.rb
@@ -4,12 +4,14 @@ module Extension
     creator 'App Extension', 'Extension::Commands::Create'
 
     register_command('Extension::Commands::Pack', "pack")
+    register_command('Extension::Commands::Register', "register")
     register_command('Extension::Commands::Push', "push")
     register_command('Extension::Commands::Serve', "serve")
   end
 
   module Commands
     autoload :Create, Project.project_filepath('commands/create')
+    autoload :Register, Project.project_filepath('commands/register')
     autoload :Pack, Project.project_filepath('commands/pack')
     autoload :Serve, Project.project_filepath('commands/serve')
     autoload :Push, Project.project_filepath('commands/push')
@@ -24,6 +26,7 @@ module Extension
 
   module Forms
     autoload :Create, Project.project_filepath('forms/create')
+    autoload :Register, Project.project_filepath('forms/register')
   end
 
   module Models

--- a/lib/project_types/extension/commands/create.rb
+++ b/lib/project_types/extension/commands/create.rb
@@ -6,20 +6,14 @@ module Extension
       options do |parser, flags|
         parser.on('--name=NAME') { |name| flags[:name] = name }
         parser.on('--type=TYPE') { |type| flags[:type] = type.upcase  }
-        parser.on('--api-key=KEY') { |key| flags[:api_key] = key.downcase }
       end
 
       def call(args, _)
         with_create_form(args) do |form|
           form.type.create(form.directory_name, @ctx)
 
-          ExtensionProject.write_project_files(
-            context: @ctx,
-            api_key: form.app.api_key,
-            api_secret: form.app.secret,
-            title: form.name,
-            type: form.type.identifier
-          )
+          ExtensionProject.write_cli_file(context: @ctx, type: form.type.identifier)
+          ExtensionProject.write_env_file(context: @ctx, title: form.name)
 
           ShopifyCli::Core::Finalize.request_cd(form.directory_name)
 

--- a/lib/project_types/extension/commands/push.rb
+++ b/lib/project_types/extension/commands/push.rb
@@ -5,12 +5,14 @@ module Extension
   module Commands
     class Push < ShopifyCli::Command
 
-      def call(*)
+      def call(args, name)
         @project = ExtensionProject.current
-        run_pack_command
+
+        Commands::Register.new(@ctx).call(args, name) unless @project.registered?
+        Commands::Pack.new(@ctx).call(args, name)
 
         CLI::UI::Frame.open(Content::Push::FRAME_TITLE) do
-          @project.registration_id? ? update_draft : confirm_before_creating_extension
+          update_draft
 
           @ctx.puts(Content::Push::SUCCESS_CONFIRMATION % @project.title)
           @ctx.puts(Content::Push::SUCCESS_INFO)
@@ -26,12 +28,6 @@ module Extension
 
       private
 
-      def run_pack_command
-        pack_command = Commands::Pack.new
-        pack_command.ctx = @ctx
-        pack_command.call({}, :push)
-      end
-
       def update_draft
         @ctx.puts(Content::Push::WAITING_TEXT)
 
@@ -42,27 +38,6 @@ module Extension
           config: @project.extension_type.config(@ctx),
           extension_context: @project.extension_type.extension_context(@ctx)
         )
-      end
-
-      def confirm_before_creating_extension
-        @ctx.puts(Content::Push::CREATE_CONFIRM_INFO)
-        continue_with_creation = CLI::UI::Prompt.confirm(Content::Push::CREATE_CONFIRM_QUESTION)
-        continue_with_creation ? create_extension : @ctx.abort(Content::Push::CREATE_ABORT)
-      end
-
-      def create_extension
-        @ctx.puts(Content::Push::WAITING_TEXT)
-
-        registration = Tasks::CreateExtension.call(
-          context: @ctx,
-          api_key: @project.app.api_key,
-          type: @project.extension_type.identifier,
-          title: @project.title,
-          config: @project.extension_type.config(@ctx),
-          extension_context: @project.extension_type.extension_context(@ctx)
-        )
-
-        @project.set_registration_id(@ctx, registration.id)
       end
     end
   end

--- a/lib/project_types/extension/commands/register.rb
+++ b/lib/project_types/extension/commands/register.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+module Extension
+  module Commands
+    class Register < ShopifyCli::Command
+      options do |parser, flags|
+        parser.on('--api_key=KEY') { |key| flags[:api_key] = key.downcase }
+      end
+
+      def call(args, command_name)
+        @project = ExtensionProject.current
+
+        CLI::UI::Frame.open(Content::Register::FRAME_TITLE) do
+          @ctx.abort(Content::Register::ALREADY_REGISTERED) if @project.registered?
+
+          with_register_form(args) do |form|
+            should_continue = confirm_registration
+            registration = should_continue ? register_extension(form.app) : @ctx.abort(Content::Register::CONFIRM_ABORT)
+
+            update_project_files(form.app, registration)
+
+            @ctx.puts(Content::Register::SUCCESS % @project.title)
+            @ctx.puts(Content::Register::SUCCESS_INFO)
+          end
+        end
+      end
+
+      def self.help
+        <<~HELP
+          Connect your local extension to a Shopify app.
+            Usage: {{command:#{ShopifyCli::TOOL_NAME} register}}
+            Options:
+              {{command:--api_key=API_KEY}} The API key used to connect an app to the extension. This can be found on the app page on Partners Dashboard.
+        HELP
+      end
+
+      private
+
+      def with_register_form(args)
+        form = Forms::Register.ask(@ctx, args, options.flags)
+        return @ctx.puts(self.class.help) if form.nil?
+
+        yield form
+      end
+
+      def confirm_registration
+        @ctx.puts(Content::Register::CONFIRM_INFO % @project.extension_type.name)
+        CLI::UI::Prompt.confirm(Content::Register::CONFIRM_QUESTION)
+      end
+
+      def register_extension(app)
+        @ctx.puts(Content::Register::WAITING_TEXT)
+
+        Tasks::CreateExtension.call(
+          context: @ctx,
+          api_key: app.api_key,
+          type: @project.extension_type.identifier,
+          title: @project.title,
+          config: {},
+          extension_context: @project.extension_type.extension_context(@ctx)
+        )
+      end
+
+      def update_project_files(app, registration)
+        ExtensionProject.write_env_file(
+          context: @ctx,
+          api_key: app.api_key,
+          api_secret: app.secret,
+          registration_id: registration.id,
+          title: @project.title
+        )
+      end
+    end
+  end
+end

--- a/lib/project_types/extension/content.rb
+++ b/lib/project_types/extension/content.rb
@@ -9,10 +9,6 @@ module Extension
       ASK_TYPE = 'What type of extension would you like to create?'
       INVALID_TYPE = 'Invalid extension type.'
 
-      ASK_APP = 'Which app would you like to associate with the extension?'
-      NO_APPS = 'You don’t have any apps. Learn more about building apps at <https://shopify.dev/concepts/apps> or try creating one using a new app using {{command:shopify create app}}.'
-      INVALID_API_KEY = 'The API key %s does not match any of your apps.'
-
       SETUP_PROJECT_FRAME_TITLE = 'Initializing Project'
 
       READY_TO_START = '{{*}} You\'re ready to start building %s! Try running `shopify serve` to start a local server.'
@@ -25,13 +21,29 @@ module Extension
       BUILD_FAILURE_MESSAGE = 'Failed to pack extension code for deployment.'
     end
 
+    module Register
+      FRAME_TITLE = 'Registering Extension'
+      WAITING_TEXT = 'Registering with Shopify...'
+
+      ALREADY_REGISTERED = 'Extension is already registered.'
+
+      LOADING_APPS = 'Loading your apps...'
+      ASK_APP = 'Which app would you like to associate with the extension?'
+      NO_APPS = '{{x}} You don’t have any apps.'
+      LEARN_ABOUT_APPS = '{{*}} Learn more about building apps at <https://shopify.dev/concepts/apps>, or try creating a new app using {{command: shopify create app.}}'
+      INVALID_API_KEY = 'The API key %s does not match any of your apps.'
+
+      CONFIRM_INFO = 'You can only create one %s extension per app, which can’t be undone.'
+      CONFIRM_QUESTION = 'Would you like to connect this extension? (y/n)'
+      CONFIRM_ABORT = 'Extension was not created.'
+
+      SUCCESS = '{{v}} Connected %s.'
+      SUCCESS_INFO = '{{*}} Run {{command: shopify push}} to push your extension to Shopify.'
+    end
+
     module Push
       FRAME_TITLE = 'Pushing your extension to Shopify'
       WAITING_TEXT = 'Pushing to Shopify...'
-
-      CREATE_CONFIRM_INFO = 'This will create an extension on the Partners Dashboard. You can only create one subscription management extension per app.'
-      CREATE_CONFIRM_QUESTION = 'This is not reversible (y/n)'
-      CREATE_ABORT = 'Pushing extension aborted by user.'
 
       SUCCESS_CONFIRMATION = '{{v}} %s has been pushed to a draft.'
       SUCCESS_INFO = '{{*}} Visit the Partner\'s Dashboard to create and publish versions.'

--- a/lib/project_types/extension/extension_project.rb
+++ b/lib/project_types/extension/extension_project.rb
@@ -1,37 +1,43 @@
 # frozen_string_literal: true
 require 'shopify_cli'
-require 'forwardable'
 
 module Extension
-  class ExtensionProject
-    extend Forwardable
-    include SmartProperties
-
+  class ExtensionProject < ShopifyCli::Project
     REGISTRATION_ID_KEY = 'EXTENSION_ID'
     EXTENSION_TYPE_KEY = 'EXTENSION_TYPE'
     TITLE_KEY = 'EXTENSION_TITLE'
 
-    def_delegators :project, :env, :directory, :config
-
-    property! :project, accepts: ShopifyCli::Project
-
     class << self
-      def current
-        ExtensionProject.new(project: ShopifyCli::Project.current)
+      def write_cli_file(context:, type:)
+        ShopifyCli::Project.write(context, :extension, EXTENSION_TYPE_KEY => type)
       end
 
-      def write_project_files(context:, api_key:, api_secret:, title:, type:)
-        ShopifyCli::Project.write(context, :extension, EXTENSION_TYPE_KEY => type)
+      def write_env_file(context:, title:, api_key: '', api_secret: '', registration_id: nil)
         ShopifyCli::Resources::EnvFile.new(
           api_key: api_key,
           secret: api_secret,
-          extra: { TITLE_KEY => title }.compact
+          extra: {
+            TITLE_KEY => title,
+            REGISTRATION_ID_KEY => registration_id,
+          }.compact
         ).write(context)
+
+        self.current.reload unless project_empty?
+      end
+
+      private
+
+      def project_empty?
+        directory(Dir.pwd).nil?
       end
     end
 
     def app
       Models::App.new(api_key: env['api_key'], secret: env['secret'])
+    end
+
+    def registered?
+      property_present?('api_key') && property_present?('secret') && registration_id?
     end
 
     def title
@@ -43,19 +49,17 @@ module Extension
     end
 
     def registration_id?
-      env[:extra].key?(REGISTRATION_ID_KEY) && registration_id > 0
+      extra_property_present?(REGISTRATION_ID_KEY) &&
+        is_integer?(get_extra_field(REGISTRATION_ID_KEY)) &&
+        registration_id > 0
     end
 
     def registration_id
       get_extra_field(REGISTRATION_ID_KEY).to_i
     end
 
-    def set_registration_id(context, new_registration_id)
-      return if new_registration_id.nil?
-      return if registration_id == new_registration_id
-
-      updated_extra = env[:extra].merge(REGISTRATION_ID_KEY => new_registration_id)
-      env.update(context, :extra, updated_extra)
+    def reload
+      @env = nil
     end
 
     private
@@ -63,6 +67,18 @@ module Extension
     def get_extra_field(key)
       extra = env[:extra] || {}
       extra[key]
+    end
+
+    def extra_property_present?(key)
+      env[:extra].key?(key) && !get_extra_field(key).nil?
+    end
+
+    def property_present?(key)
+      !env[key].nil? && !env[key].strip.empty?
+    end
+
+    def is_integer?(value)
+      value.to_i.to_s == value
     end
   end
 end

--- a/lib/project_types/extension/forms/create.rb
+++ b/lib/project_types/extension/forms/create.rb
@@ -3,12 +3,9 @@
 module Extension
   module Forms
     class Create < ShopifyCli::Form
-      flag_arguments :name, :type, :api_key
-
-      attr_reader :app
+      flag_arguments :name, :type
 
       def ask
-        self.app = ask_app
         self.type = ask_type
         self.name = ask_name
       end
@@ -16,10 +13,6 @@ module Extension
       def directory_name
         @directory_name ||= self.name.strip.gsub(/( )/, '_').downcase
       end
-
-      protected
-
-      attr_writer :app
 
       private
 
@@ -42,25 +35,6 @@ module Extension
           end
         end
       end
-
-      def ask_app
-        apps = Tasks::GetApps.call(context: ctx)
-        ctx.abort(Content::Create::NO_APPS) if apps.empty?
-
-        if !api_key.nil?
-          found_app = apps.find { |app| app.api_key == api_key }
-          ctx.abort(Content::Create::INVALID_API_KEY % api_key) if found_app.nil?
-          found_app
-        else
-          CLI::UI::Prompt.ask(Content::Create::ASK_APP) do |handler|
-            apps.each do |app|
-              handler.option("#{app.title} by #{app.business_name}") { app }
-            end
-          end
-        end
-      end
-
-      private
 
       def ask_with_reprompt(initial_value:, break_condition:, prompt_message:, reprompt_message:)
         value = initial_value

--- a/lib/project_types/extension/forms/register.rb
+++ b/lib/project_types/extension/forms/register.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Extension
+  module Forms
+    class Register < ShopifyCli::Form
+      flag_arguments :api_key
+
+      attr_reader :app
+
+      def ask
+        self.app = ask_app
+      end
+
+      private
+
+      attr_writer :app
+
+      def ask_app
+        apps = load_apps
+
+        if !api_key.nil?
+          found_app = apps.find { |app| app.api_key == api_key }
+          ctx.abort(Content::Register::INVALID_API_KEY % api_key) if found_app.nil?
+          found_app
+        else
+          CLI::UI::Prompt.ask(Content::Register::ASK_APP) do |handler|
+            apps.each do |app|
+              handler.option("#{app.title} by #{app.business_name}") { app }
+            end
+          end
+        end
+      end
+
+      def load_apps
+        ctx.puts(Content::Register::LOADING_APPS)
+        apps = Tasks::GetApps.call(context: ctx)
+
+        apps.empty? ? abort_no_apps : apps
+      end
+
+      def abort_no_apps
+        ctx.puts(Content::Register::NO_APPS)
+        ctx.puts(Content::Register::LEARN_ABOUT_APPS)
+        raise ShopifyCli::AbortSilent
+      end
+    end
+  end
+end

--- a/test/project_types/extension/commands/create_test.rb
+++ b/test/project_types/extension/commands/create_test.rb
@@ -18,22 +18,15 @@ module Extension
       def test_runs_type_create_and_writes_project_files
         name = "My Ext"
         directory_name = 'my_ext'
-        app = Models::App.new(api_key: '1234', secret: '4567')
-        stub_get_organizations([organization(name: "Organization One", apps: [app])])
 
         @test_extension_type.expects(:create).with(directory_name, @context).once
-        ExtensionProject.expects(:write_project_files).with(
-          context: @context,
-          api_key: app.api_key,
-          api_secret: app.secret,
-          title: name,
-          type: @test_extension_type.identifier
-        ).once
+        ExtensionProject.expects(:write_cli_file).with(context: @context, type: @test_extension_type.identifier).once
+        ExtensionProject.expects(:write_env_file).with(context: @context, title: name).once
         ShopifyCli::Core::Finalize.expects(:request_cd).with(directory_name).once
 
         io = capture_io do
           Commands::Create.ctx = @context
-          arguments = %W(extension --name=#{name} --type=#{@test_extension_type.identifier} --api-key=#{app.api_key})
+          arguments = %W(extension --name=#{name} --type=#{@test_extension_type.identifier})
           Commands::Create.call(arguments, 'create', 'create')
         end
 

--- a/test/project_types/extension/commands/push_test.rb
+++ b/test/project_types/extension/commands/push_test.rb
@@ -13,12 +13,6 @@ module Extension
         super
         ShopifyCli::ProjectType.load_type(:extension)
         setup_temp_project
-
-        @registration = Models::Registration.new(
-          id: 42,
-          type: @type.identifier,
-          title: @title
-        )
       end
 
       def test_help_implemented
@@ -27,61 +21,33 @@ module Extension
         end
       end
 
-      def test_does_not_run_create_if_user_does_not_confirm
+      def test_runs_register_command_if_extension_not_yet_registered
+        @project.expects(:registered?).returns(false).once
+        Commands::Register.any_instance.expects(:call).once
         Commands::Pack.any_instance.expects(:call).once
-        Tasks::UpdateDraft.expects(:call).never
-        Tasks::CreateExtension.expects(:call).never
+        Tasks::UpdateDraft.any_instance.expects(:call).once
 
-        @context.expects(:abort).with(Content::Push::CREATE_ABORT).once
-
-        CLI::UI::Prompt
-          .expects(:confirm)
-          .with(Content::Push::CREATE_CONFIRM_QUESTION)
-          .returns(false).once
-
-        capture_io { run_push }.join
+        run_push
       end
 
-      def test_runs_create_if_no_registration_id_is_present_and_user_confirms_then_sets_registration_id
-        refute @project.registration_id?
+      def test_does_not_run_register_command_if_extension_already_registered
+        assert @project.registered?
+
+        Commands::Register.any_instance.expects(:call).never
         Commands::Pack.any_instance.expects(:call).once
-        Tasks::UpdateDraft.expects(:call).never
+        Tasks::UpdateDraft.any_instance.expects(:call).once
 
-        CLI::UI::Prompt
-          .expects(:confirm)
-          .with(Content::Push::CREATE_CONFIRM_QUESTION)
-          .returns(true).once
-
-        Tasks::CreateExtension.expects(:call)
-          .with(
-            context: @context,
-            api_key: @api_key,
-            type: @type.identifier,
-            title: @title,
-            config: @type.config(@context),
-            extension_context: @type.extension_context(@context)
-          )
-          .returns(@registration).once
-
-        io = capture_io { run_push }
-
-        assert_equal @registration.id, @project.registration_id
-        confirm_content_output(io: io, expected_content: [
-          Content::Push::WAITING_TEXT,
-          Content::Push::SUCCESS_CONFIRMATION % @title,
-          Content::Push::SUCCESS_INFO
-        ])
+        run_push
       end
 
-      def test_runs_update_if_registration_id_is_present
-        @project.set_registration_id(@context, @registration.id)
-        Commands::Pack.any_instance.expects(:call).once
-        Tasks::CreateExtension.expects(:call).never
+      def test_packs_and_updates_draft_if_extension_registered
+        assert @project.registered?
 
+        Commands::Pack.any_instance.expects(:call).once
         Tasks::UpdateDraft.any_instance.expects(:call).with(
           context: @context,
           api_key: @api_key,
-          registration_id: @registration.id,
+          registration_id: @registration_id,
           config: @type.config(@context),
           extension_context: @type.extension_context(@context)
         ).once

--- a/test/project_types/extension/commands/register_test.rb
+++ b/test/project_types/extension/commands/register_test.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+require 'test_helper'
+require 'project_types/extension/extension_test_helpers'
+
+module Extension
+  module Commands
+    class RegisterTest < MiniTest::Test
+      include TestHelpers::FakeUI
+      include ExtensionTestHelpers::TempProjectSetup
+      include ExtensionTestHelpers::Content
+      include ExtensionTestHelpers::Stubs::GetOrganizations
+
+      def setup
+        super
+        ShopifyCli::ProjectType.load_type(:extension)
+        setup_temp_project(api_key: '', api_secret: '', registration_id: nil)
+
+        @app = Models::App.new(api_key: @api_key, secret: @api_secret)
+        stub_get_organizations([organization(name: "Organization One", apps: [@app])])
+      end
+
+      def test_help_implemented
+        assert_nothing_raised { refute_nil Commands::Register.help }
+      end
+
+      def test_if_extension_is_already_registered_the_register_command_aborts
+        @project.expects(:registered?).returns(true).once
+        Tasks::CreateExtension.any_instance.expects(:call).never
+        ExtensionProject.expects(:write_env_file).never
+
+        io = capture_io_and_assert_raises(ShopifyCli::Abort) { run_register_command }
+
+        confirm_content_output(io: io, expected_content: Content::Register::ALREADY_REGISTERED)
+      end
+
+      def test_does_not_run_create_if_user_does_not_confirm
+        refute @project.registered?
+        Tasks::CreateExtension.any_instance.expects(:call).never
+        ExtensionProject.expects(:write_env_file).never
+
+        CLI::UI::Prompt.expects(:confirm).with(Content::Register::CONFIRM_QUESTION).returns(false).once
+
+        io = capture_io_and_assert_raises(ShopifyCli::Abort) { run_register_command }
+
+        confirm_content_output(io: io, expected_content: [
+          Content::Register::CONFIRM_ABORT,
+          Content::Register::CONFIRM_INFO % @test_extension_type.name,
+        ])
+      end
+
+      def test_creates_the_extension_if_user_confirms
+        registration = Models::Registration.new(id: 55, type: @test_extension_type.identifier, title: @project.title)
+        refute @project.registered?
+
+        CLI::UI::Prompt.expects(:confirm).with(Content::Register::CONFIRM_QUESTION).returns(true).once
+        Tasks::CreateExtension.any_instance.expects(:call).with(
+          context: @context,
+          api_key: @app.api_key,
+          type: @test_extension_type.identifier,
+          title: @project.title,
+          config: {},
+          extension_context: @test_extension_type.extension_context(@context)
+        ).returns(registration).once
+
+        ExtensionProject.expects(:write_env_file).with(
+          context: @context,
+          api_key: @app.api_key,
+          api_secret: @app.secret,
+          registration_id: registration.id,
+          title: @project.title
+        ).once
+
+        io = capture_io { run_register_command }
+
+        confirm_content_output(io: io, expected_content: [
+          Content::Register::CONFIRM_INFO % @test_extension_type.name,
+          Content::Register::WAITING_TEXT,
+          Content::Register::SUCCESS % @project.title,
+          Content::Register::SUCCESS_INFO,
+        ])
+      end
+
+      def run_register_command(api_key: @api_key)
+        Commands::Register.ctx = @context
+        Commands::Register.call(
+          %W(--api_key=#{api_key}),
+          :register
+        )
+      end
+    end
+  end
+end

--- a/test/project_types/extension/extension_project_test.rb
+++ b/test/project_types/extension/extension_project_test.rb
@@ -12,20 +12,69 @@ module Extension
       setup_temp_project
     end
 
-    def test_write_project_files_creates_env_and_shopify_cli_files
-      @new_context = TestHelpers::FakeContext.new(root: Dir.mktmpdir)
-      FileUtils.cd(@new_context.root)
-      ExtensionProject.write_project_files(
-        context: @new_context,
-        api_key: 'test_key',
-        api_secret: 'test_secret',
-        title: 'Registration Title',
-        type: @type.identifier
+    def test_write_cli_file_create_shopify_cli_yml_file
+      new_context = TestHelpers::FakeContext.new(root: Dir.mktmpdir)
+      FileUtils.cd(new_context.root)
+
+      ExtensionProject.write_cli_file(context: new_context, type: @type.identifier)
+
+      assert File.exists?('.shopify-cli.yml')
+      assert_equal :extension, ShopifyCli::Project.current_project_type
+      assert_equal @type, ExtensionProject.current.extension_type
+    end
+
+    def test_write_env_file_creates_env_file
+      api_key = '1234'
+      api_secret = '5678'
+      title = 'Test Title'
+      registration_id = 55
+
+      new_context = TestHelpers::FakeContext.new(root: Dir.mktmpdir)
+      FileUtils.cd(new_context.root)
+
+      ExtensionProject.write_cli_file(context: new_context, type: @type.identifier)
+      ExtensionProject.write_env_file(
+        context: new_context,
+        api_key: api_key,
+        api_secret: api_secret,
+        title: title,
+        registration_id: registration_id
       )
 
       assert File.exists?('.env')
-      assert File.exists?('.shopify-cli.yml')
-      assert_equal :extension, ShopifyCli::Project.current_project_type
+      project = ExtensionProject.current
+      assert_equal api_key, project.app.api_key
+      assert_equal api_secret, project.app.secret
+      assert_equal title, project.title
+      assert_equal registration_id, project.registration_id
+    end
+
+    def test_ensures_registered_is_true_only_if_api_key_api_secret_and_registration_id_are_present
+      new_ctx = TestHelpers::FakeContext.new(root: Dir.mktmpdir)
+      FileUtils.cd(new_ctx.root)
+      ExtensionProject.write_cli_file(context: new_ctx, type: @type.identifier)
+      project = ExtensionProject.current
+
+      ExtensionProject.write_env_file(context: new_ctx, title: 'title')
+      refute project.registered?
+
+      ExtensionProject.write_env_file(context: new_ctx, api_key: '1234', title: 'title')
+      refute project.registered?
+
+      ExtensionProject.write_env_file(context: new_ctx, api_key: '1234', api_secret: '456', title: 'title')
+      refute project.registered?
+
+      ExtensionProject.write_env_file(context: new_ctx, api_key: '', api_secret: '', title: 'title', registration_id: 5)
+      refute project.registered?
+
+      ExtensionProject.write_env_file(
+        context: new_ctx,
+        api_key: '1234',
+        api_secret: '456',
+        title: 'title',
+        registration_id: 55
+      )
+      assert project.registered?
     end
 
     def test_can_access_app_specific_values_as_an_app
@@ -48,50 +97,15 @@ module Extension
       assert_equal @type.identifier, @project.extension_type.identifier
     end
 
-    def test_can_write_and_read_registration_id_values
-      refute @project.registration_id?
-      @project.set_registration_id(@context, 42)
-
-      assert_equal 42, @project.registration_id
-    end
-
     def test_detects_if_registration_id_is_missing_or_invalid
-      @project.set_registration_id(@context, "")
+      ExtensionProject.write_env_file(context: @context, title: 'Test')
       refute @project.registration_id?
 
-      @project.set_registration_id(@context, 0)
+      ExtensionProject.write_env_file(context: @context, title: 'Test', registration_id: 0)
       refute @project.registration_id?
-    end
 
-    def test_overrides_an_existing_registration_id
-      @project.set_registration_id(@context, 42)
-      @project.set_registration_id(@context, 52)
-
-      assert_equal 52, @project.registration_id
-    end
-
-    def test_only_writes_env_file_if_registration_id_is_different
-      ShopifyCli::Resources::EnvFile.any_instance.expects(:write).once
-
-      @project.set_registration_id(@context, 42)
-      @project.set_registration_id(@context, 42)
-    end
-
-    def test_set_registration_id_does_not_write_the_env_file_if_registration_id_empty
-      ShopifyCli::Resources::EnvFile.any_instance.expects(:write).never
-
-      @project.set_registration_id(@context, nil)
-    end
-
-    def test_delegate_standard_project_methods_to_internal_project_instance
-      @project.project.expects(:env).once
-      @project.env
-
-      @project.project.expects(:directory).once
-      @project.directory
-
-      @project.project.expects(:config).once
-      @project.config
+      ExtensionProject.write_env_file(context: @context, title: 'Test', registration_id: 'wrong')
+      refute @project.registration_id?
     end
   end
 end

--- a/test/project_types/extension/extension_test_helpers/content.rb
+++ b/test/project_types/extension/extension_test_helpers/content.rb
@@ -10,6 +10,14 @@ module Extension
           assert_includes all_output, CLI::UI.fmt(expected)
         end
       end
+
+      def capture_io_and_assert_raises(exception_class)
+        io = []
+        io << capture_io do
+          exception = assert_raises(exception_class) { yield }
+          io << CLI::UI.fmt(exception.message.gsub("{{x}} ", ""))
+        end
+      end
     end
   end
 end

--- a/test/project_types/extension/extension_test_helpers/temp_project_setup.rb
+++ b/test/project_types/extension/extension_test_helpers/temp_project_setup.rb
@@ -5,20 +5,28 @@ module Extension
     module TempProjectSetup
       include ExtensionTestHelpers::TestExtensionSetup
 
-      def setup_temp_project(api_key: 'TEST_KEY', api_secret: 'TEST_SECRET', title: 'Test', type: @test_extension_type)
+      def setup_temp_project(
+        api_key: 'TEST_KEY',
+        api_secret: 'TEST_SECRET',
+        title: 'Test',
+        type: @test_extension_type,
+        registration_id: 55)
+
         @context = TestHelpers::FakeContext.new(root: Dir.mktmpdir)
         @api_key = api_key
         @api_secret = api_secret
         @title = title
         @type = type
+        @registration_id = registration_id
 
         FileUtils.cd(@context.root)
-        ExtensionProject.write_project_files(
+        ExtensionProject.write_cli_file(context: @context, type: @type.identifier)
+        ExtensionProject.write_env_file(
           context: @context,
           api_key: @api_key,
           api_secret: @api_secret,
           title: @title,
-          type: @type.identifier
+          registration_id: @registration_id
         )
 
         @project = ExtensionProject.current

--- a/test/project_types/extension/forms/create_test.rb
+++ b/test/project_types/extension/forms/create_test.rb
@@ -11,7 +11,6 @@ module Extension
       def setup
         super
         @app = Models::App.new(title: 'Fake', api_key: '1234', secret: '4567', business_name: 'Fake Business')
-        Tasks::GetApps.any_instance.expects(:call).with(context: @context).returns([@app]).at_least_once
       end
 
       def test_returns_defined_attributes_if_valid
@@ -82,44 +81,14 @@ module Extension
         end
       end
 
-      def test_aborts_and_informs_user_if_there_are_no_apps
-        Tasks::GetApps.any_instance.unstub(:call)
-        Tasks::GetApps.any_instance.expects(:call).with(context: @context).returns([]).once
-        @context.expects(:abort).with(Content::Create::NO_APPS).raises(ShopifyCli::Abort).once
-
-        capture_io { ask }
-      end
-
-      def test_accepts_the_api_key_to_associate_with_extension
-        form = ask(api_key: '1234')
-        assert_equal form.app, @app
-      end
-
-      def test_prompts_the_user_to_choose_an_app_to_associate_with_extension_if_no_app_is_provided
-        CLI::UI::Prompt.expects(:ask).with(Content::Create::ASK_APP)
-
-        capture_io do
-          ask(api_key: nil)
-        end
-      end
-
-      def test_fails_with_invalid_api_key_to_associate_with_extension
-        api_key = '00001'
-
-        io = capture_io { ask(api_key: api_key) }
-
-        assert_match(Content::Create::INVALID_API_KEY % api_key, io.join)
-      end
-
       private
 
-      def ask(name: 'test-extension', type: @test_extension_type.identifier, api_key: @app.api_key)
+      def ask(name: 'test-extension', type: @test_extension_type.identifier)
         Create.ask(
           @context,
           [],
           name: name,
           type: type,
-          api_key: api_key,
         )
       end
     end

--- a/test/project_types/extension/forms/register_test.rb
+++ b/test/project_types/extension/forms/register_test.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+require 'test_helper'
+require 'project_types/extension/extension_test_helpers'
+
+module Extension
+  module Forms
+    class RegisterTest < MiniTest::Test
+      include TestHelpers::FakeUI
+      include ExtensionTestHelpers::TestExtensionSetup
+      include ExtensionTestHelpers::Content
+
+      def setup
+        super
+        @app = Models::App.new(title: 'Fake', api_key: '1234', secret: '4567', business_name: 'Fake Business')
+        Tasks::GetApps.any_instance.expects(:call).with(context: @context).returns([@app]).at_least_once
+      end
+
+      def test_aborts_and_informs_user_if_there_are_no_apps
+        Tasks::GetApps.any_instance.unstub(:call)
+        Tasks::GetApps.any_instance.expects(:call).with(context: @context).returns([]).once
+
+        io = capture_io do
+          assert_raises(ShopifyCli::AbortSilent) { ask }
+        end
+
+        confirm_content_output(io: io, expected_content: [
+          Content::Register::NO_APPS,
+          Content::Register::LEARN_ABOUT_APPS
+        ])
+      end
+
+      def test_accepts_the_api_key_to_associate_with_extension
+        form = ask(api_key: '1234')
+        assert_equal form.app, @app
+      end
+
+      def test_prompts_the_user_to_choose_an_app_to_associate_with_extension_if_no_app_is_provided
+        CLI::UI::Prompt.expects(:ask).with(Content::Register::ASK_APP)
+
+        capture_io do
+          ask(api_key: nil)
+        end
+      end
+
+      def test_fails_with_invalid_api_key_to_associate_with_extension
+        api_key = '00001'
+
+        io = capture_io { ask(api_key: api_key) }
+
+        assert_match(Content::Register::INVALID_API_KEY % api_key, io.join)
+      end
+
+      private
+
+      def ask(api_key: @app.api_key)
+        Register.ask(@context, [], api_key: api_key)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Pair @jantnovi 
Pair @victor-jeung 

### WHY are these changes introduced?
Part of: https://github.com/Shopify/app-extension-libs/issues/508

UX has requested that we split the `push` concept into two separate commands:
1) `register` - Defines the associated app and creates the extension + empty draft.
2) `push` - Updates the draft of the extension created during `register`

### WHAT is this pull request doing?
Split push into two new commands: `register` and `push`. This was a bit more involved than initially conceived and required a few workarounds of the current CLI expectations:

- Update `ExtensionProject` to write out blank `api_key` and `api_secret` to `.env` on create.
  - This was required because when writing the `.env` the CLI assumes that we have already associated the app. The only workaround we currently have is to write out blanks for these keys and update them later.
  - Added a `registered?` check to the `ExtensionProject` to easily check the status of these fields.
  - This caused another problem where the CLI `project` is never expecting the `.env` file to be rewritten and therefore it memoizies it. In this case, we needed to reload the `env` when we are writing it back out.
- Remove `app` from `create` command
  - The create command no longer needed app data. We removed the request from the `create` form and removed it from the create flags.
- Create `register`
  - Created a new `register` form that holds the `app` questions removed from the `create` form
  - Added the `api_key` flag to this command instead
  - Logic from `push` to confirm extension creation and call `CreateExtension` task was moved here
- Update `push`
  - Removed the conditional logic of `CreateExtension` or `UpdateDraft`
  - Moved all create code to `register`