### PR TITLE
Display last_user_interaction_at on successful push

### DIFF
--- a/lib/graphql/extension_create.graphql
+++ b/lib/graphql/extension_create.graphql
@@ -4,6 +4,10 @@ mutation ExtensionCreate($api_key: String!, $type: ExtensionType!, $title: Strin
       id
       type
       title
+      draftVersion {
+        registrationId
+        lastUserInteractionAt
+      }
     }
     userErrors {
       field

--- a/lib/graphql/extension_update_draft.graphql
+++ b/lib/graphql/extension_update_draft.graphql
@@ -3,6 +3,7 @@ mutation ExtensionUpdateDraft($api_key: String!, $registration_id: ID!, $config:
     extensionVersion {
       registrationId
       context
+      lastUserInteractionAt
     }
     userErrors {
       field

--- a/lib/project_types/extension/content.rb
+++ b/lib/project_types/extension/content.rb
@@ -45,7 +45,7 @@ module Extension
       FRAME_TITLE = 'Pushing your extension to Shopify'
       WAITING_TEXT = 'Pushing to Shopify...'
 
-      SUCCESS_CONFIRMATION = '{{v}} %s has been pushed to a draft.'
+      SUCCESS_CONFIRMATION = '{{v}} Pushed %s to a draft at %s.'
       SUCCESS_INFO = '{{*}} Visit the Partner\'s Dashboard to create and publish versions.'
     end
 

--- a/lib/project_types/extension/models/registration.rb
+++ b/lib/project_types/extension/models/registration.rb
@@ -9,6 +9,7 @@ module Extension
       property! :id, accepts: Integer
       property! :type, accepts: String
       property! :title, accepts: String
+      property! :draft_version, accepts: Extension::Models::Version
 
       def self.valid_title?(title)
         !title.nil? && !title.strip.empty? && title.length <= MAX_TITLE_LENGTH

--- a/lib/project_types/extension/models/version.rb
+++ b/lib/project_types/extension/models/version.rb
@@ -6,7 +6,8 @@ module Extension
       include SmartProperties
 
       property! :registration_id, accepts: Integer
-      property :context, accepts: String
+      property! :last_user_interaction_at, accepts: Time
+      property  :context, accepts: String
     end
   end
 end

--- a/lib/project_types/extension/tasks/create_extension.rb
+++ b/lib/project_types/extension/tasks/create_extension.rb
@@ -7,13 +7,18 @@ module Extension
       include UserErrors
 
       GRAPHQL_FILE = 'extension_create'
+
       ID_FIELD = 'id'
       TYPE_FIELD = 'type'
       TITLE_FIELD = 'title'
+      DRAFT_VERSION_FIELD = 'draftVersion'
+      DRAFT_VERSION_REGISTRATION_ID_FIELD = %W(#{DRAFT_VERSION_FIELD} registrationId)
+      DRAFT_VERSION_LAST_USER_INTERACTION_AT_FIELD = %W(#{DRAFT_VERSION_FIELD} lastUserInteractionAt)
+
       RESPONSE_FIELD = %w(data extensionCreate)
       REGISTRATION_FIELD = 'extensionRegistration'
-      PARSE_ERROR = 'Unable to parse response from Partners Dashboard.'
 
+      PARSE_ERROR = 'Unable to parse response from Partners Dashboard.'
 
       def call(context:, api_key:, type:, title:, config:, extension_context: nil)
         input = {
@@ -40,7 +45,11 @@ module Extension
         Models::Registration.new(
           id: registration_hash[ID_FIELD].to_i,
           type: registration_hash[TYPE_FIELD],
-          title: registration_hash[TITLE_FIELD]
+          title: registration_hash[TITLE_FIELD],
+          draft_version: Models::Version.new(
+            registration_id: registration_hash.dig(*DRAFT_VERSION_REGISTRATION_ID_FIELD).to_i,
+            last_user_interaction_at: Time.parse(registration_hash.dig(*DRAFT_VERSION_LAST_USER_INTERACTION_AT_FIELD)),
+          ),
         )
       end
     end

--- a/lib/project_types/extension/tasks/update_draft.rb
+++ b/lib/project_types/extension/tasks/update_draft.rb
@@ -7,10 +7,14 @@ module Extension
       include UserErrors
 
       GRAPHQL_FILE = 'extension_update_draft'
+
       REGISTRATION_ID_FIELD = 'registrationId'
       CONTEXT_FIELD = 'context'
+      LAST_USER_INTERACTION_AT_FIELD = 'lastUserInteractionAt'
+
       RESPONSE_FIELD = %w(data extensionUpdateDraft)
       VERSION_FIELD = 'extensionVersion'
+
       PARSE_ERROR = 'Unable to parse response from Partners Dashboard.'
 
       def call(context:, api_key:, registration_id:, config:, extension_context:)
@@ -36,7 +40,8 @@ module Extension
 
         Models::Version.new(
           registration_id: version_hash[REGISTRATION_ID_FIELD].to_i,
-          context: version_hash[CONTEXT_FIELD]
+          context: version_hash[CONTEXT_FIELD],
+          last_user_interaction_at: Time.parse(version_hash[LAST_USER_INTERACTION_AT_FIELD])
         )
       end
     end

--- a/test/project_types/extension/commands/push_test.rb
+++ b/test/project_types/extension/commands/push_test.rb
@@ -13,6 +13,11 @@ module Extension
         super
         ShopifyCli::ProjectType.load_type(:extension)
         setup_temp_project
+
+        @version = Models::Version.new(
+          registration_id: 42,
+          last_user_interaction_at: Time.now.utc
+        )
       end
 
       def test_help_implemented
@@ -23,9 +28,10 @@ module Extension
 
       def test_runs_register_command_if_extension_not_yet_registered
         @project.expects(:registered?).returns(false).once
+
         Commands::Register.any_instance.expects(:call).once
-        Commands::Build.any_instance.expects(:call).once
-        Tasks::UpdateDraft.any_instance.expects(:call).once
+        Commands::Build.any_instance.stubs(:call)
+        Tasks::UpdateDraft.any_instance.stubs(:call).returns(@version)
 
         run_push
       end
@@ -34,32 +40,68 @@ module Extension
         assert @project.registered?
 
         Commands::Register.any_instance.expects(:call).never
-        Commands::Build.any_instance.expects(:call).once
-        Tasks::UpdateDraft.any_instance.expects(:call).once
+        Commands::Build.any_instance.stubs(:call)
+        Tasks::UpdateDraft.any_instance.stubs(:call).returns(@version)
 
         run_push
       end
 
-      def test_packs_and_updates_draft_if_extension_registered
-        assert @project.registered?
-
+      def test_runs_pack_command
         Commands::Build.any_instance.expects(:call).once
-        Tasks::UpdateDraft.any_instance.expects(:call).with(
-          context: @context,
-          api_key: @api_key,
-          registration_id: @registration_id,
-          config: @type.config(@context),
-          extension_context: @type.extension_context(@context)
-        ).once
+        Tasks::UpdateDraft.any_instance.stubs(:call).returns(@version)
+
+        run_push
+      end
+
+      def test_updates_the_extensions_draft_version
+        Commands::Build.any_instance.stubs(:call)
+        Tasks::UpdateDraft.any_instance.expects(:call)
+          .with(
+            context: @context,
+            api_key: @api_key,
+            registration_id: @registration_id,
+            config: @type.config(@context),
+            extension_context: @type.extension_context(@context)
+          )
+          .returns(@version)
+          .once
+
+        run_push
+      end
+
+      def test_shows_confirmation_message_with_time_updated_on_successful_update
+        @version.last_user_interaction_at = Time.parse("2020-05-07 19:01:56 UTC")
+        Commands::Build.any_instance.stubs(:call)
+        Tasks::UpdateDraft.any_instance.stubs(:call).returns(@version)
 
         io = capture_io { run_push }
 
         confirm_content_output(io: io, expected_content: [
           Content::Push::WAITING_TEXT,
-          Content::Push::SUCCESS_CONFIRMATION % @title,
+          Content::Push::SUCCESS_CONFIRMATION % [
+            @title,
+            'May 07, 2020 19:01:56 UTC'
+          ],
           Content::Push::SUCCESS_INFO
         ])
       end
+
+      def test_displays_time_the_draft_was_updated_at_in_utc
+        response_time = '2020-05-07T19:01:56-04:00'
+        expected_formatted_time_in_utc = 'May 07, 2020 23:01:56 UTC'
+
+        @version.last_user_interaction_at = Time.parse(response_time)
+        Commands::Build.any_instance.stubs(:call)
+        Tasks::UpdateDraft.any_instance.stubs(:call).returns(@version)
+
+        io = capture_io { run_push }
+
+        confirm_content_output(io: io, expected_content: [
+          Content::Push::SUCCESS_CONFIRMATION % [@title, expected_formatted_time_in_utc]
+        ])
+      end
+
+      private
 
       def run_push
         push_command = Commands::Push.new

--- a/test/project_types/extension/commands/register_test.rb
+++ b/test/project_types/extension/commands/register_test.rb
@@ -49,7 +49,16 @@ module Extension
       end
 
       def test_creates_the_extension_if_user_confirms
-        registration = Models::Registration.new(id: 55, type: @test_extension_type.identifier, title: @project.title)
+        registration = Models::Registration.new(
+          id: 55,
+          type: @test_extension_type.identifier,
+          title: @project.title,
+          draft_version: Models::Version.new(
+            registration_id: 55,
+            last_user_interaction_at: Time.now.utc,
+          )
+
+        )
         refute @project.registered?
 
         CLI::UI::Prompt.expects(:confirm).with(Content::Register::CONFIRM_QUESTION).returns(true).once

--- a/test/project_types/extension/extension_test_helpers/stubs/create_extension.rb
+++ b/test/project_types/extension/extension_test_helpers/stubs/create_extension.rb
@@ -23,13 +23,18 @@ module Extension
         end
 
         def stub_create_extension_success(**args)
+          registration_id = rand(9999)
           stub_create_extension(args) do |title, type|
             {
               extensionCreate: {
                 extensionRegistration: {
-                  id: rand(9999),
+                  id: registration_id,
                   type: type,
-                  title: title
+                  title: title,
+                  draftVersion: {
+                    registrationId: registration_id,
+                    lastUserInteractionAt: Time.now.utc.to_s
+                  }
                 },
                 userErrors: []
               },

--- a/test/project_types/extension/extension_test_helpers/stubs/update_draft.rb
+++ b/test/project_types/extension/extension_test_helpers/stubs/update_draft.rb
@@ -26,7 +26,8 @@ module Extension
               extensionUpdateDraft: {
                 extensionVersion: {
                   registrationId: registration_id,
-                  context: extension_context
+                  context: extension_context,
+                  lastUserInteractionAt: Time.now.utc.to_s
                 },
                 Tasks::UserErrors::USER_ERRORS_FIELD => []
               }

--- a/test/project_types/extension/tasks/create_extension_test.rb
+++ b/test/project_types/extension/tasks/create_extension_test.rb
@@ -42,8 +42,9 @@ module Extension
         )
 
         assert_kind_of Models::Registration, created_registration
-        assert_equal created_registration.type, @fake_type
-        assert_equal created_registration.title, @fake_title
+        assert_equal @fake_type, created_registration.type
+        assert_equal @fake_title, created_registration.title
+        assert_kind_of Time, created_registration.draft_version.last_user_interaction_at
       end
 
       def test_aborts_with_parse_error_if_no_created_registration_or_errors_are_returned

--- a/test/project_types/extension/tasks/update_draft_test.rb
+++ b/test/project_types/extension/tasks/update_draft_test.rb
@@ -39,6 +39,7 @@ module Extension
         assert_kind_of Models::Version, updated_draft
         assert_equal @registration_id, updated_draft.registration_id
         assert_equal @extension_context, updated_draft.context
+        assert_kind_of Time, updated_draft.last_user_interaction_at
       end
 
       def test_aborts_with_parse_error_if_no_updated_version_or_errors_are_returned


### PR DESCRIPTION
~Currently based off this PR: https://github.com/Shopify/shopify-app-cli-extensions/pull/38~

Part of: https://github.com/Shopify/app-extension-libs/issues/448

### WHY are these changes introduced?
We want to display the timestamp that represents the last time a version was successfully interacted with by a user on a successful 'push' of an extension in the Shopify CLI.

### WHAT is this pull request doing?
- displays the timestamp in the format `[Month Day, Year] [24 hr time] [TZ]`. ie. `April 8, 2020 14:23:12 UTC`. As per UX we will always display the time in UTC right now.
![Screen Shot 2020-05-19 at 2 27 38 PM](https://user-images.githubusercontent.com/4079241/82364201-f32eb200-99dc-11ea-85d6-5d1afd255f33.png)

CODE
- updates the gql queries, stubs, and the creating and updating processes for extensions. The processes have to perform some strange field transformation work to accommodate the difference between camel and snake casing (i.e. gql results come in as `extensionVersion` but by ruby convention we'd like to see the same as `extension_version`). it would be cool to genericize this behaviour, and also to potentially externalize creating registrations and versions, which is currently done in the process. Because this opens up a lot of discussion and we are trying to move quickly I have opted to follow the established patterns, and we can revisit this in our cleanup tasks when we have more breathing room.

UX 
- updated the confirmation text to align with the prescribed text in the UX doc
- Another thing of note here is that I can continually push and push without actually making any changes to the draft version and still get a new timestamp to represent the latest interaction. This is because while we break early in the `UpdateDraft` process in core if the attributes we pass are empty, we do execute the update if the attributes are unchanged from their current state.