### PR TITLE
Make extension project type hidden

### DIFF
--- a/lib/project_types/extension/cli.rb
+++ b/lib/project_types/extension/cli.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 module Extension
   class Project < ShopifyCli::ProjectType
+    hidden_project_type
     creator 'App Extension', 'Extension::Commands::Create'
 
     register_command('Extension::Commands::Build', "build")

--- a/test/project_types/extension/commands/create_test.rb
+++ b/test/project_types/extension/commands/create_test.rb
@@ -35,6 +35,14 @@ module Extension
           Content::Create::LEARN_MORE % @test_extension_type.name
         ])
       end
+      
+      def test_help_does_not_load_extension_project_type
+        io = capture_io do
+          run_cmd('create --help')
+        end
+        output = io.join
+        refute_match('extension', output)
+      end
     end
   end
 end


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?
We will launch the extension project as hidden. 
https://github.com/Shopify/shopify-app-cli-extensions/pull/35 needs to be merged first.
Fixes https://github.com/Shopify/app-extension-libs/issues/398
 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
Makes extension project type hidden.
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
### 🎩 
![1](https://user-images.githubusercontent.com/56688159/82283596-d2c31100-9964-11ea-9f98-6dbdb8f2d9d2.png)

![2](https://user-images.githubusercontent.com/56688159/82351585-c2de1800-99ca-11ea-9170-8b946b9be266.png)
