### PR TITLE
Fix writing extension project data to yml file

### DIFF
--- a/lib/project_types/extension/extension_project.rb
+++ b/lib/project_types/extension/extension_project.rb
@@ -9,7 +9,12 @@ module Extension
 
     class << self
       def write_cli_file(context:, type:)
-        ShopifyCli::Project.write(context, :extension, EXTENSION_TYPE_KEY => type)
+        ShopifyCli::Project.write(
+          context,
+          app_type: :extension,
+          organization_id: nil,
+          "#{EXTENSION_TYPE_KEY}": type
+        )
       end
 
       def write_env_file(context:, title:, api_key: '', api_secret: '', registration_id: nil)


### PR DESCRIPTION
### WHY are these changes introduced?

We merged in the upstream changes today, but some changes to way the base shopify project writes data to the yml file broke extension projects. This fixes the immediate issue, but we will need a better fix.

![Screen Shot 2020-05-21 at 1 25 49 PM](https://user-images.githubusercontent.com/4079241/82588853-5a796d00-9b69-11ea-807e-43783a783e4d.png)