### PR TITLE
Remove duplicate register content

### DIFF
--- a/lib/project_types/extension/content.rb
+++ b/lib/project_types/extension/content.rb
@@ -41,26 +41,6 @@ module Extension
       SUCCESS_INFO = '{{*}} Run {{command: shopify push}} to push your extension to Shopify.'
     end
 
-    module Register
-      FRAME_TITLE = 'Registering Extension'
-      WAITING_TEXT = 'Registering with Shopify...'
-
-      ALREADY_REGISTERED = 'Extension is already registered.'
-
-      LOADING_APPS = 'Loading your apps...'
-      ASK_APP = 'Which app would you like to associate with the extension?'
-      NO_APPS = '{{x}} You don’t have any apps.'
-      LEARN_ABOUT_APPS = '{{*}} Learn more about building apps at <https://shopify.dev/concepts/apps>, or try creating a new app using {{command: shopify create app.}}'
-      INVALID_API_KEY = 'The API key %s does not match any of your apps.'
-
-      CONFIRM_INFO = 'You can only create one %s extension per app, which can’t be undone.'
-      CONFIRM_QUESTION = 'Would you like to connect this extension? (y/n)'
-      CONFIRM_ABORT = 'Extension was not created.'
-
-      SUCCESS = '{{v}} Connected %s.'
-      SUCCESS_INFO = '{{*}} Run {{command: shopify push}} to push your extension to Shopify.'
-    end
-
     module Push
       FRAME_TITLE = 'Pushing your extension to Shopify'
       WAITING_TEXT = 'Pushing to Shopify...'


### PR DESCRIPTION
This is based off another PR: https://github.com/Shopify/shopify-app-cli-extensions/pull/38

Some clashing changes caused the `Content::Register` module to be duplicated. This caused a bunch of warnings in the console. Introduced here: https://github.com/Shopify/shopify-app-cli-extensions/commit/8961dd5103061e01e52ddde3f91ce1dd9c2e7119


### WHAT is this pull request doing?
- just remove the duplicate module

Before
![Screen Shot 2020-05-21 at 4 06 57 PM](https://user-images.githubusercontent.com/4079241/82601210-33c53180-9b7d-11ea-990b-768a4b04d710.png)


After
![Screen Shot 2020-05-21 at 4 07 18 PM](https://user-images.githubusercontent.com/4079241/82601215-36278b80-9b7d-11ea-9a33-2c03ff295f77.png)
