### PR TITLE
Creating the Tunnel command

### DIFF
--- a/lib/project_types/extension/cli.rb
+++ b/lib/project_types/extension/cli.rb
@@ -8,6 +8,7 @@ module Extension
     register_command('Extension::Commands::Register', "register")
     register_command('Extension::Commands::Push', "push")
     register_command('Extension::Commands::Serve', "serve")
+    register_command('Extension::Commands::Tunnel', "tunnel")
   end
 
   module Commands
@@ -16,6 +17,7 @@ module Extension
     autoload :Build, Project.project_filepath('commands/build')
     autoload :Serve, Project.project_filepath('commands/serve')
     autoload :Push, Project.project_filepath('commands/push')
+    autoload :Tunnel, Project.project_filepath('commands/tunnel')
   end
 
   module Tasks

--- a/lib/project_types/extension/commands/tunnel.rb
+++ b/lib/project_types/extension/commands/tunnel.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+require 'shopify_cli'
+
+module Extension
+  module Commands
+    class Tunnel < ShopifyCli::Command
+      options do |parser, flags|
+        parser.on('--port=PORT') { |port| flags[:port] = port }
+      end
+
+      AUTH_SUBCOMMAND = 'auth'
+      START_SUBCOMMAND = 'start'
+      STOP_SUBCOMMAND = 'stop'
+      DEFAULT_PORT = 39351
+
+      def call(args, _name)
+        subcommand = args.shift
+
+        case subcommand
+        when AUTH_SUBCOMMAND then authorize(args)
+        when START_SUBCOMMAND then ShopifyCli::Tunnel.start(@ctx, port: port)
+        when STOP_SUBCOMMAND then ShopifyCli::Tunnel.stop(@ctx)
+        else @ctx.puts(self.class.help)
+        end
+      end
+
+      private
+
+      def self.help
+        <<~HELP
+          Start or stop an http tunnel to your local development extension using ngrok.
+            Usage: {{command:%s tunnel [ auth | start | stop ]}}
+        HELP
+      end
+
+      def self.extended_help
+        <<~HELP
+          {{bold:Subcommands:}}
+
+            {{cyan:auth}}: Writes an ngrok auth token to ~/.ngrok2/ngrok.yml to connect with an ngrok account. Visit https://dashboard.ngrok.com/signup to sign up.
+              Usage: {{command:%1$s tunnel auth <token>}}
+
+            {{cyan:start}}: Starts an ngrok tunnel, will print the URL for an existing tunnel if already running.
+              Usage: {{command:%1$s tunnel start}}
+
+            {{cyan:stop}}: Stops the ngrok tunnel.
+              Usage: {{command:%1$s tunnel stop}}
+        HELP
+      end
+
+      def port
+        return DEFAULT_PORT unless options.flags.key?(:port)
+
+        port = options.flags[:port].to_i
+        @ctx.abort(Content::Tunnel::INVALID_PORT % options.flags[:port]) unless port > 0
+        port
+      end
+
+      def authorize(args)
+        token = args.shift
+
+        if token.nil?
+          @ctx.puts(Content::Tunnel::MISSING_TOKEN)
+          @ctx.puts("#{self.class.help}\n#{self.class.extended_help}")
+        else
+          ShopifyCli::Tunnel.auth(@ctx, token)
+        end
+      end
+    end
+  end
+end

--- a/lib/project_types/extension/content.rb
+++ b/lib/project_types/extension/content.rb
@@ -55,6 +55,11 @@ module Extension
       SERVE_FAILURE_MESSAGE = 'Failed to run extension code for testing.'
     end
 
+    module Tunnel
+      MISSING_TOKEN = '{{x}} {{red:auth requires a token argument}}. Find it on your ngrok dashboard: {{underline:https://dashboard.ngrok.com/auth/your-authtoken}}.'
+      INVALID_PORT = '%s is not a valid port.'
+    end
+
     module Models
       TYPES = {
         ARGO: {


### PR DESCRIPTION
### WHY are these changes introduced?
Closes: https://github.com/Shopify/app-extension-libs/issues/535

For the new Cross-Sells extension it will be required to have a tunnel to your local environment. This PR adds the tunnel command and reuses as much of the Core CLI functionality as possible.

### WHAT is this pull request doing?
Adds the `tunnel` command and it's three subcommands `auth`, `start`, `stop`.

Notes:
- Core `Tunnel` of `ShopifyCLI` keeps `port` as a constant. This solution extends and overrides with a settable port. This should be added to the core CLI after we merge in. This will be added to the cleanup task.