### PR TITLE
Create checkout post purchase extension type model

### DIFF
--- a/lib/project_types/extension/content.rb
+++ b/lib/project_types/extension/content.rb
@@ -64,6 +64,10 @@ module Extension
         Extension::Models::Types::SubscriptionManagement::IDENTIFIER => {
           name: 'Subscription Management',
           tagline: '(limit 1 per app)',
+        },
+        Extension::Models::Types::CheckoutPostPurchase::IDENTIFIER => {
+          name: 'Checkout Post Purchase',
+          tagline: '',
         }
       }
     end

--- a/lib/project_types/extension/models/types/checkout_post_purchase.rb
+++ b/lib/project_types/extension/models/types/checkout_post_purchase.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+require 'base64'
+
+module Extension
+  module Models
+    module Types
+      class CheckoutPostPurchase < Models::Type
+        IDENTIFIER = 'CHECKOUT_POST_PURCHASE'
+
+        def create(directory_name, context)
+          Models::Types::Argo.create(directory_name, IDENTIFIER, context)
+        end
+
+        def config(context)
+          Models::Types::Argo.config(context)
+        end
+      end
+    end
+  end
+end

--- a/test/project_types/extension/models/types/checkout_post_purchase_test.rb
+++ b/test/project_types/extension/models/types/checkout_post_purchase_test.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+module Extension
+  module Models
+    module Types
+      class CheckoutPostPurchaseTest < MiniTest::Test
+        def setup
+          super
+          ShopifyCli::ProjectType.load_type(:extension)
+          @checkout_post_purchase = Models::Type.load_type(CheckoutPostPurchase::IDENTIFIER)
+        end
+
+        def test_create_uses_standard_argo_create_implementation
+          directory_name = 'checkout_post_purchase'
+
+          Models::Types::Argo
+            .expects(:create)
+            .with(directory_name, CheckoutPostPurchase::IDENTIFIER, @context)
+            .once
+
+          @checkout_post_purchase.create(directory_name, @context)
+        end
+
+        def test_config_uses_standard_argo_config_implementation
+          Models::Types::Argo.expects(:config).with(@context).once
+
+          @checkout_post_purchase.config(@context)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

As the first step of https://github.com/Shopify/app-extension-libs/issues/532
I needed to create the `checkout_post_purchase` extension type model.
<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
It is introducing a new Argo extension type named `checkout-post-purchase` on the CLI.
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
### 🎩 
![Screen Shot 2020-05-26 at 1 56 57 PM](https://user-images.githubusercontent.com/56688159/82934030-dd7b3880-9f58-11ea-92e8-b66304e80435.png)
