### PR TITLE
[WIP] Adding location to register command output

### DIFF
--- a/lib/graphql/extension_create.graphql
+++ b/lib/graphql/extension_create.graphql
@@ -4,6 +4,7 @@ mutation ExtensionCreate($api_key: String!, $type: ExtensionType!, $title: Strin
       id
       type
       title
+      location
       draftVersion {
         registrationId
         lastUserInteractionAt

--- a/lib/project_types/extension/commands/register.rb
+++ b/lib/project_types/extension/commands/register.rb
@@ -21,6 +21,7 @@ module Extension
 
             @ctx.puts(Content::Register::SUCCESS % @project.title)
             @ctx.puts(Content::Register::SUCCESS_INFO)
+            @ctx.puts(registration.location)
           end
         end
       end

--- a/lib/project_types/extension/models/registration.rb
+++ b/lib/project_types/extension/models/registration.rb
@@ -10,6 +10,7 @@ module Extension
       property! :type, accepts: String
       property! :title, accepts: String
       property! :draft_version, accepts: Extension::Models::Version
+      property! :location, accepts: String
 
       def self.valid_title?(title)
         !title.nil? && !title.strip.empty? && title.length <= MAX_TITLE_LENGTH

--- a/lib/project_types/extension/tasks/create_extension.rb
+++ b/lib/project_types/extension/tasks/create_extension.rb
@@ -11,6 +11,7 @@ module Extension
       ID_FIELD = 'id'
       TYPE_FIELD = 'type'
       TITLE_FIELD = 'title'
+      LOCATION_FIELD = 'location'
       DRAFT_VERSION_FIELD = 'draftVersion'
       DRAFT_VERSION_REGISTRATION_ID_FIELD = %W(#{DRAFT_VERSION_FIELD} registrationId)
       DRAFT_VERSION_LAST_USER_INTERACTION_AT_FIELD = %W(#{DRAFT_VERSION_FIELD} lastUserInteractionAt)
@@ -46,6 +47,7 @@ module Extension
           id: registration_hash[ID_FIELD].to_i,
           type: registration_hash[TYPE_FIELD],
           title: registration_hash[TITLE_FIELD],
+          location: registration_hash[LOCATION_FIELD],
           draft_version: Models::Version.new(
             registration_id: registration_hash.dig(*DRAFT_VERSION_REGISTRATION_ID_FIELD).to_i,
             last_user_interaction_at: Time.parse(registration_hash.dig(*DRAFT_VERSION_LAST_USER_INTERACTION_AT_FIELD)),

--- a/test/project_types/extension/commands/register_test.rb
+++ b/test/project_types/extension/commands/register_test.rb
@@ -53,11 +53,11 @@ module Extension
           id: 55,
           type: @test_extension_type.identifier,
           title: @project.title,
+          location: 'https://partners.shopify.com/manage_extensions/55',
           draft_version: Models::Version.new(
             registration_id: 55,
             last_user_interaction_at: Time.now.utc,
           )
-
         )
         refute @project.registered?
 

--- a/test/project_types/extension/extension_test_helpers/stubs/create_extension.rb
+++ b/test/project_types/extension/extension_test_helpers/stubs/create_extension.rb
@@ -31,6 +31,7 @@ module Extension
                   id: registration_id,
                   type: type,
                   title: title,
+                  location: "https://partners.shopify.com/manage_extensions/#{registration_id}",
                   draftVersion: {
                     registrationId: registration_id,
                     lastUserInteractionAt: Time.now.utc.to_s

--- a/test/project_types/extension/tasks/create_extension_test.rb
+++ b/test/project_types/extension/tasks/create_extension_test.rb
@@ -44,6 +44,7 @@ module Extension
         assert_kind_of Models::Registration, created_registration
         assert_equal @fake_type, created_registration.type
         assert_equal @fake_title, created_registration.title
+        assert_equal "https://partners.shopify.com/manage_extensions/#{created_registration.id}", created_registration.location
         assert_kind_of Time, created_registration.draft_version.last_user_interaction_at
       end
 


### PR DESCRIPTION
### WHY are these changes introduced?
The UX has us outputting the location of the extension once registered.  This PR updates our GraphQL layer to fetch the location and outputs it after a successful `register` command.

### WHAT is this pull request doing?
- Request `location` from GraphQL
- Add `location` property to `Registration` model
- Output `location` at the end of `register` command