### PR TITLE
Change the extension type models in the CLI

### DIFF
--- a/lib/project_types/extension/models/types/argo.rb
+++ b/lib/project_types/extension/models/types/argo.rb
@@ -4,8 +4,11 @@ require 'base64'
 module Extension
   module Models
     module Types
-      module Argo
-        GIT_TEMPLATE = 'https://github.com/Shopify/shopify-app-extension-template.git'.freeze
+      class Argo
+        include SmartProperties
+
+        GIT_ADMIN_TEMPLATE = 'https://github.com/Shopify/shopify-app-extension-template.git'.freeze
+        GIT_CHECKOUT_TEMPLATE = 'https://github.com/Shopify/argo-checkout-template.git'.freeze
         SCRIPT_PATH = %w(build main.js).freeze
 
         GIT_DIRECTORY = '.git'.freeze
@@ -16,48 +19,58 @@ module Extension
         INITIALIZE_TYPE_PARAMETER = '--type=%s'.freeze
 
         class << self
-          def create(directory_name, identifier, context)
-            clone_template(directory_name, context)
-            initialize_project(identifier, context)
-            cleanup(context)
+          def admin
+            @admin ||= Argo.new(git_template: GIT_ADMIN_TEMPLATE)
           end
 
-          def config(context)
-            filepath = File.join(context.root, SCRIPT_PATH)
-            context.abort(Content::Models::TYPES[:ARGO][:missing_file_error]) unless File.exists?(filepath)
-
-            begin
-              {
-                serialized_script: Base64.strict_encode64(File.open(filepath).read.chomp)
-              }
-            rescue Exception
-              context.abort(Content::Models::TYPES[:ARGO][:script_prepare_error])
-            end
+          def checkout
+            @checkout ||= Argo.new(git_template: GIT_CHECKOUT_TEMPLATE)
           end
+        end
 
-          def clone_template(directory_name, context)
-            ShopifyCli::Git.clone(GIT_TEMPLATE, directory_name, ctx: context)
-            context.root = File.join(context.root, directory_name)
+        property! :git_template, accepts: String
+
+        def create(directory_name, identifier, context)
+          clone_template(directory_name, context)
+          initialize_project(identifier, context)
+          cleanup(context)
+        end
+
+        def config(context)
+          filepath = File.join(context.root, SCRIPT_PATH)
+          context.abort(Content::Models::TYPES[:ARGO][:missing_file_error]) unless File.exists?(filepath)
+
+          begin
+            {
+              serialized_script: Base64.strict_encode64(File.open(filepath).read.chomp)
+            }
+          rescue Exception
+            context.abort(Content::Models::TYPES[:ARGO][:script_prepare_error])
           end
+        end
 
-          def initialize_project(identifier, context)
-            JsDeps.install(context)
+        def clone_template(directory_name, context)
+          ShopifyCli::Git.clone(git_template, directory_name, ctx: context)
+          context.root = File.join(context.root, directory_name)
+        end
 
-            initialize_command = JsDeps.new(ctx: context).yarn? ? YARN_INITIALIZE_COMMAND : NPM_INITIALIZE_COMMAND
-            initialize_command = initialize_command + [INITIALIZE_TYPE_PARAMETER % identifier]
+        def initialize_project(identifier, context)
+          JsDeps.install(context)
 
-            CLI::UI::Frame.open(Content::Create::SETUP_PROJECT_FRAME_TITLE) do
-              context.system(*initialize_command, chdir: context.root)
-            end
+          initialize_command = JsDeps.new(ctx: context).yarn? ? YARN_INITIALIZE_COMMAND : NPM_INITIALIZE_COMMAND
+          initialize_command = initialize_command + [INITIALIZE_TYPE_PARAMETER % identifier]
+
+          CLI::UI::Frame.open(Content::Create::SETUP_PROJECT_FRAME_TITLE) do
+            context.system(*initialize_command, chdir: context.root)
           end
+        end
 
-          def cleanup(context)
-            begin
-              context.rm_r(GIT_DIRECTORY)
-              context.rm_r(SCRIPTS_DIRECTORY)
-            rescue Errno::ENOENT => e
-              context.debug(e)
-            end
+        def cleanup(context)
+          begin
+            context.rm_r(GIT_DIRECTORY)
+            context.rm_r(SCRIPTS_DIRECTORY)
+          rescue Errno::ENOENT => e
+            context.debug(e)
           end
         end
       end

--- a/lib/project_types/extension/models/types/checkout_post_purchase.rb
+++ b/lib/project_types/extension/models/types/checkout_post_purchase.rb
@@ -8,11 +8,11 @@ module Extension
         IDENTIFIER = 'CHECKOUT_POST_PURCHASE'
 
         def create(directory_name, context)
-          Models::Types::Argo.create(directory_name, IDENTIFIER, context)
+          Models::Types::Argo.checkout.create(directory_name, IDENTIFIER, context)
         end
 
         def config(context)
-          Models::Types::Argo.config(context)
+          Models::Types::Argo.checkout.config(context)
         end
       end
     end

--- a/lib/project_types/extension/models/types/subscription_management.rb
+++ b/lib/project_types/extension/models/types/subscription_management.rb
@@ -8,11 +8,11 @@ module Extension
         IDENTIFIER = 'SUBSCRIPTION_MANAGEMENT'
 
         def create(directory_name, context)
-          Models::Types::Argo.create(directory_name, IDENTIFIER, context)
+          Models::Types::Argo.admin.create(directory_name, IDENTIFIER, context)
         end
 
         def config(context)
-          Models::Types::Argo.config(context)
+          Models::Types::Argo.admin.config(context)
         end
       end
     end

--- a/test/project_types/extension/models/types/checkout_post_purchase_test.rb
+++ b/test/project_types/extension/models/types/checkout_post_purchase_test.rb
@@ -14,7 +14,7 @@ module Extension
         def test_create_uses_standard_argo_create_implementation
           directory_name = 'checkout_post_purchase'
 
-          Models::Types::Argo
+          Models::Types::Argo.checkout
             .expects(:create)
             .with(directory_name, CheckoutPostPurchase::IDENTIFIER, @context)
             .once
@@ -23,7 +23,7 @@ module Extension
         end
 
         def test_config_uses_standard_argo_config_implementation
-          Models::Types::Argo.expects(:config).with(@context).once
+          Models::Types::Argo.checkout.expects(:config).with(@context).once
 
           @checkout_post_purchase.config(@context)
         end

--- a/test/project_types/extension/models/types/subscription_management_test.rb
+++ b/test/project_types/extension/models/types/subscription_management_test.rb
@@ -14,7 +14,7 @@ module Extension
         def test_create_uses_standard_argo_create_implementation
           directory_name = 'subscription_management'
 
-          Models::Types::Argo
+          Models::Types::Argo.admin
             .expects(:create)
             .with(directory_name, SubscriptionManagement::IDENTIFIER, @context)
             .once
@@ -23,7 +23,7 @@ module Extension
         end
 
         def test_config_uses_standard_argo_config_implementation
-          Models::Types::Argo.expects(:config).with(@context).once
+          Models::Types::Argo.admin.expects(:config).with(@context).once
 
           @subscription_management.config(@context)
         end

--- a/test/project_types/extension/models/types_test.rb
+++ b/test/project_types/extension/models/types_test.rb
@@ -11,7 +11,7 @@ module Extension
       end
 
       def test_loads_all_extension_types_within_types_folder
-        extension_type_count = 1
+        extension_type_count = 2
         assert_equal extension_type_count, Models::Type.repository.size
       end
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/app-extension-libs/issues/587
`checkout_post_purchase` is another Argo extension type which needs its own template within Argo type model.
Pairing with @fredriculrich
<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
Changing the extension type models to include the `checkout_post_purchase` template as well.
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
### 🎩 
![1](https://user-images.githubusercontent.com/56688159/83185516-1baf5e00-a0f9-11ea-8dc3-c6f995b70088.png)

![2](https://user-images.githubusercontent.com/56688159/83185527-210ca880-a0f9-11ea-9c2a-32752e636e9e.png)

![Screen Shot 2020-06-01 at 11 44 07 AM](https://user-images.githubusercontent.com/56688159/83426639-78628f80-a3fd-11ea-9459-9625c75260d5.png)

![3](https://user-images.githubusercontent.com/56688159/83185542-2538c600-a0f9-11ea-8011-288fe6d7449c.png)

![4](https://user-images.githubusercontent.com/56688159/83185559-2b2ea700-a0f9-11ea-8a28-8d381c451383.png)

