### PR TITLE
Adding FakeExtensionProject

### DIFF
--- a/lib/project_types/extension/extension_project.rb
+++ b/lib/project_types/extension/extension_project.rb
@@ -79,7 +79,7 @@ module Extension
     end
 
     def is_integer?(value)
-      value.to_i.to_s == value
+      value.to_i.to_s == value.to_s
     end
   end
 end

--- a/test/project_types/extension/extension_test_helpers.rb
+++ b/test/project_types/extension/extension_test_helpers.rb
@@ -2,6 +2,7 @@
 
 module Extension
   module ExtensionTestHelpers
+    autoload :FakeExtensionProject, 'project_types/extension/extension_test_helpers/fake_extension_project'
     autoload :TestExtension, 'project_types/extension/extension_test_helpers/test_extension'
     autoload :TestExtensionSetup, 'project_types/extension/extension_test_helpers/test_extension_setup'
     autoload :TempProjectSetup, 'project_types/extension/extension_test_helpers/temp_project_setup'

--- a/test/project_types/extension/extension_test_helpers/fake_extension_project.rb
+++ b/test/project_types/extension/extension_test_helpers/fake_extension_project.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Extension
+  module ExtensionTestHelpers
+    class FakeExtensionProject < Extension::ExtensionProject
+      include SmartProperties
+
+      property :directory
+      property :title
+      property :type
+      property :registration_id
+      property :api_key
+      property :api_secret
+
+      def config
+        {
+          ExtensionProjectKeys::EXTENSION_TYPE_KEY => type.identifier
+        }
+      end
+
+      def env
+        @env ||= ShopifyCli::Resources::EnvFile.new(
+          api_key: api_key,
+          secret: api_secret,
+          extra: {
+            ExtensionProjectKeys::TITLE_KEY => title,
+            ExtensionProjectKeys::REGISTRATION_ID_KEY => registration_id
+          }
+        )
+      end
+    end
+  end
+end

--- a/test/project_types/extension/extension_test_helpers/temp_project_setup.rb
+++ b/test/project_types/extension/extension_test_helpers/temp_project_setup.rb
@@ -3,6 +3,7 @@
 module Extension
   module ExtensionTestHelpers
     module TempProjectSetup
+      include TestHelpers::Partners
       include ExtensionTestHelpers::TestExtensionSetup
 
       def setup_temp_project(
@@ -12,24 +13,22 @@ module Extension
         type: @test_extension_type,
         registration_id: 55)
 
-        @context = TestHelpers::FakeContext.new(root: Dir.mktmpdir)
+        @context = TestHelpers::FakeContext.new(root: '/fake/root')
         @api_key = api_key
         @api_secret = api_secret
         @title = title
         @type = type
         @registration_id = registration_id
 
-        FileUtils.cd(@context.root)
-        ExtensionProject.write_cli_file(context: @context, type: @type.identifier)
-        ExtensionProject.write_env_file(
-          context: @context,
+        @project = FakeExtensionProject.new(
           api_key: @api_key,
           api_secret: @api_secret,
           title: @title,
+          type: @type,
           registration_id: @registration_id
         )
 
-        @project = ExtensionProject.current
+        ExtensionProject.stubs(:current).returns(@project)
       end
     end
   end

--- a/test/project_types/extension/messages/message_loading_test.rb
+++ b/test/project_types/extension/messages/message_loading_test.rb
@@ -55,6 +55,8 @@ module Extension
 
       def test_load_current_type_messages_calls_messages_for_type_with_type_if_there_is_a_current_project
         setup_temp_project
+        ShopifyCli::Project.expects(:has_current?).returns(true).once
+        ShopifyCli::Project.stubs(:current).returns(@project).once
         Messages::MessageLoading.expects(:messages_for_type).with(@type.identifier).once
 
         Messages::MessageLoading.load_current_type_messages


### PR DESCRIPTION
### WHY are these changes introduced?
The previous `ExtensionProjectSetup` would create a temporary directory and write out the CLI and ENV files. This is a lot of overhead and could end up being pretty flaky. This PR removes the need to create the temporary directory and files,

### WHAT is this pull request doing?
- Update `ExtensionProjectSetup` to create a `FakeExtensionProject`
- Create `FakeExtensionProject`
- Update `ExtensionProject` tests to work with the new fake setup