### PR TITLE
Display Partner's dashboard extension URL after push success

### DIFF
--- a/lib/graphql/extension_update_draft.graphql
+++ b/lib/graphql/extension_update_draft.graphql
@@ -4,6 +4,7 @@ mutation ExtensionUpdateDraft($api_key: String!, $registration_id: ID!, $config:
       registrationId
       context
       lastUserInteractionAt
+      location
     }
     userErrors {
       field

--- a/lib/project_types/extension/commands/push.rb
+++ b/lib/project_types/extension/commands/push.rb
@@ -12,7 +12,7 @@ module Extension
 
         CLI::UI::Frame.open(@ctx.message('push.frame_title')) do
           updated_draft_version = update_draft
-          show_confirmation_message(updated_draft_version.last_user_interaction_at)
+          show_confirmation_message(updated_draft_version.last_user_interaction_at, updated_draft_version.location)
         end
       end
 
@@ -25,9 +25,9 @@ module Extension
 
       private
 
-      def show_confirmation_message(confirmed_at)
+      def show_confirmation_message(confirmed_at, location)
         @ctx.puts(@ctx.message('push.success_confirmation', project.title, format_time(confirmed_at)))
-        @ctx.puts(@ctx.message('push.success_info'))
+        @ctx.puts(@ctx.message('push.success_info', location))
       end
 
       def format_time(time)

--- a/lib/project_types/extension/messages/messages.rb
+++ b/lib/project_types/extension/messages/messages.rb
@@ -35,8 +35,8 @@ module Extension
       push: {
         frame_title: 'Pushing your extension to Shopify',
         waiting_text: 'Pushing code to Shopify...',
-        success_confirmation: '{{v}} Pushed %s to a draft on %s.',
-        success_info: '{{*}} Visit <extension URL> to version and publish your extension.',
+        success_confirmation: '{{v}} Pushed %s to a draft at %s.',
+        success_info: '{{*}} Visit %s to version and publish your extension.',
       },
       serve: {
         frame_title: 'Serving extension...',

--- a/lib/project_types/extension/models/version.rb
+++ b/lib/project_types/extension/models/version.rb
@@ -8,6 +8,7 @@ module Extension
       property! :registration_id, accepts: Integer
       property! :last_user_interaction_at, accepts: Time
       property  :context, accepts: String
+      property  :location, accepts: String
     end
   end
 end

--- a/lib/project_types/extension/tasks/update_draft.rb
+++ b/lib/project_types/extension/tasks/update_draft.rb
@@ -11,6 +11,7 @@ module Extension
       REGISTRATION_ID_FIELD = 'registrationId'
       CONTEXT_FIELD = 'context'
       LAST_USER_INTERACTION_AT_FIELD = 'lastUserInteractionAt'
+      LOCATION_FIELD = 'location'
 
       RESPONSE_FIELD = %w(data extensionUpdateDraft)
       VERSION_FIELD = 'extensionVersion'
@@ -22,9 +23,8 @@ module Extension
           api_key: api_key,
           registration_id: registration_id,
           config: JSON.generate(config),
-          extension_context: extension_context
+          extension_context: extension_context,
         }
-
         response = ShopifyCli::PartnersAPI.query(context, GRAPHQL_FILE, input).dig(*RESPONSE_FIELD)
         context.abort(PARSE_ERROR) if response.nil?
 
@@ -41,7 +41,8 @@ module Extension
         Models::Version.new(
           registration_id: version_hash[REGISTRATION_ID_FIELD].to_i,
           context: version_hash[CONTEXT_FIELD],
-          last_user_interaction_at: Time.parse(version_hash[LAST_USER_INTERACTION_AT_FIELD])
+          last_user_interaction_at: Time.parse(version_hash[LAST_USER_INTERACTION_AT_FIELD]),
+          location: version_hash[LOCATION_FIELD]
         )
       end
     end

--- a/test/project_types/extension/commands/push_test.rb
+++ b/test/project_types/extension/commands/push_test.rb
@@ -46,7 +46,7 @@ module Extension
         run_push
       end
 
-      def test_runs_pack_command
+      def test_runs_build_command
         Commands::Build.any_instance.expects(:call).once
         Tasks::UpdateDraft.any_instance.stubs(:call).returns(@version)
 
@@ -71,6 +71,7 @@ module Extension
 
       def test_shows_confirmation_message_with_time_updated_on_successful_update
         @version.last_user_interaction_at = Time.parse("2020-05-07 19:01:56 UTC")
+        @version.location = "https://www.fakeurl.com"
         Commands::Build.any_instance.stubs(:call)
         Tasks::UpdateDraft.any_instance.stubs(:call).returns(@version)
 
@@ -79,7 +80,7 @@ module Extension
         assert_message_output(io: io, expected_content: [
           @context.message('push.waiting_text'),
           @context.message('push.success_confirmation', @title, 'May 07, 2020 19:01:56 UTC'),
-          @context.message('push.success_info')
+          @context.message('push.success_info', 'https://www.fakeurl.com')
         ])
       end
 

--- a/test/project_types/extension/extension_test_helpers/stubs/update_draft.rb
+++ b/test/project_types/extension/extension_test_helpers/stubs/update_draft.rb
@@ -12,7 +12,7 @@ module Extension
               api_key: api_key,
               registration_id: registration_id,
               config: JSON.generate(config),
-              extension_context: extension_context
+              extension_context: extension_context,
             },
             resp: {
               data: yield(registration_id, config, extension_context)
@@ -27,7 +27,8 @@ module Extension
                 extensionVersion: {
                   registrationId: registration_id,
                   context: extension_context,
-                  lastUserInteractionAt: Time.now.utc.to_s
+                  lastUserInteractionAt: Time.now.utc.to_s,
+                  location: 'https://www.fakeurl.com'
                 },
                 Tasks::UserErrors::USER_ERRORS_FIELD => []
               }

--- a/test/project_types/extension/tasks/update_draft_test.rb
+++ b/test/project_types/extension/tasks/update_draft_test.rb
@@ -16,12 +16,13 @@ module Extension
         @registration_id = 42
         @config = { }
         @extension_context = 'fake#context'
+        @location = 'https://www.fakeurl.com'
 
         @input = {
           api_key: @api_key,
           registration_id: @registration_id,
           config: @config,
-          extension_context: @extension_context
+          extension_context: @extension_context,
         }
       end
 
@@ -33,12 +34,12 @@ module Extension
           api_key: @api_key,
           registration_id: @registration_id,
           config: @config,
-          extension_context: @extension_context
+          extension_context: @extension_context,
         )
-
         assert_kind_of Models::Version, updated_draft
         assert_equal @registration_id, updated_draft.registration_id
         assert_equal @extension_context, updated_draft.context
+        assert_equal @location, updated_draft.location
         assert_kind_of Time, updated_draft.last_user_interaction_at
       end
 
@@ -51,7 +52,7 @@ module Extension
             api_key: @api_key,
             registration_id: @registration_id,
             config: @config,
-            extension_context: @extension_context
+            extension_context: @extension_context,
           )
         end
 
@@ -68,7 +69,7 @@ module Extension
             api_key: @api_key,
             registration_id: @registration_id,
             config: @config,
-            extension_context: @extension_context
+            extension_context: @extension_context,
           )
         end
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?
Fixes https://github.com/Shopify/app-extension-libs/issues/562
As part of a success message, after a push command in CLI, a Partner's dashboard URL for the recently added extension is expected.
<!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
Displaying Partner's dashboard extension URL after a successful push command:
   - Changing the update draft graphql task in the CLI to fetch the version location
   - Changing the Version object on the CLI to have a location
   - Presenting the location to the user as part of the success message for the push command

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
### 🎩 
![Screen Shot 2020-06-05 at 10 41 20 AM](https://user-images.githubusercontent.com/56688159/83891470-326a3c00-a71b-11ea-81ad-0db14a65cdf5.png)

![2](https://user-images.githubusercontent.com/56688159/83920068-fb5f4f00-a749-11ea-801f-aa63a67db64e.png)
