### PR TITLE
Abort on invalid type

### DIFF
--- a/lib/project_types/extension/cli.rb
+++ b/lib/project_types/extension/cli.rb
@@ -18,6 +18,7 @@ module Extension
   end
 
   module Commands
+    autoload :ExtensionCommand, Project.project_filepath('commands/extension_command')
     autoload :Create, Project.project_filepath('commands/create')
     autoload :Register, Project.project_filepath('commands/register')
     autoload :Build, Project.project_filepath('commands/build')

--- a/lib/project_types/extension/commands/build.rb
+++ b/lib/project_types/extension/commands/build.rb
@@ -3,7 +3,7 @@ require 'shopify_cli'
 
 module Extension
   module Commands
-    class Build < ShopifyCli::Command
+    class Build < ExtensionCommand
       hidden_command
 
       YARN_BUILD_COMMAND = %w(yarn build)

--- a/lib/project_types/extension/commands/extension_command.rb
+++ b/lib/project_types/extension/commands/extension_command.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+require 'shopify_cli'
+
+module Extension
+  module Commands
+    class ExtensionCommand < ShopifyCli::Command
+      def project
+        @project ||= ExtensionProject.current
+      end
+
+      def extension_type
+        @extension_type ||= begin
+          unless Models::Type.valid?(project.extension_type_identifier)
+            @ctx.abort(@ctx.message('errors.unknown_type', project.extension_type_identifier))
+          end
+
+          Models::Type.load_type(project.extension_type_identifier)
+        end
+      end
+    end
+  end
+end

--- a/lib/project_types/extension/commands/push.rb
+++ b/lib/project_types/extension/commands/push.rb
@@ -3,13 +3,11 @@ require 'shopify_cli'
 
 module Extension
   module Commands
-    class Push < ShopifyCli::Command
+    class Push < ExtensionCommand
       TIME_DISPLAY_FORMAT = "%B %d, %Y %H:%M:%S %Z"
 
       def call(args, name)
-        @project = ExtensionProject.current
-
-        Commands::Register.new(@ctx).call(args, name) unless @project.registered?
+        Commands::Register.new(@ctx).call(args, name) unless project.registered?
         Commands::Build.new(@ctx).call(args, name)
 
         CLI::UI::Frame.open(@ctx.message('push.frame_title')) do
@@ -28,7 +26,7 @@ module Extension
       private
 
       def show_confirmation_message(confirmed_at)
-        @ctx.puts(@ctx.message('push.success_confirmation', @project.title, format_time(confirmed_at)))
+        @ctx.puts(@ctx.message('push.success_confirmation', project.title, format_time(confirmed_at)))
         @ctx.puts(@ctx.message('push.success_info'))
       end
 
@@ -45,10 +43,10 @@ module Extension
         with_waiting_text do
           Tasks::UpdateDraft.call(
             context: @ctx,
-            api_key: @project.app.api_key,
-            registration_id: @project.registration_id,
-            config: @project.extension_type.config(@ctx),
-            extension_context: @project.extension_type.extension_context(@ctx)
+            api_key: project.app.api_key,
+            registration_id: project.registration_id,
+            config: extension_type.config(@ctx),
+            extension_context: extension_type.extension_context(@ctx)
           )
         end
       end

--- a/lib/project_types/extension/commands/register.rb
+++ b/lib/project_types/extension/commands/register.rb
@@ -2,16 +2,14 @@
 
 module Extension
   module Commands
-    class Register < ShopifyCli::Command
+    class Register < ExtensionCommand
       options do |parser, flags|
         parser.on('--api_key=KEY') { |key| flags[:api_key] = key.downcase }
       end
 
       def call(args, command_name)
-        @project = ExtensionProject.current
-
         CLI::UI::Frame.open(@ctx.message('register.frame_title')) do
-          @ctx.abort(@ctx.message('register.already_registered')) if @project.registered?
+          @ctx.abort(@ctx.message('register.already_registered')) if project.registered?
 
           with_register_form(args) do |form|
             should_continue = confirm_registration(form.app)
@@ -19,7 +17,7 @@ module Extension
 
             update_project_files(form.app, registration)
 
-            @ctx.puts(@ctx.message('register.success', @project.title, form.app.title))
+            @ctx.puts(@ctx.message('register.success', project.title, form.app.title))
             @ctx.puts(@ctx.message('register.success_info'))
           end
         end
@@ -44,7 +42,7 @@ module Extension
       end
 
       def confirm_registration(app)
-        @ctx.puts(@ctx.message('register.confirm_info', @project.extension_type.name))
+        @ctx.puts(@ctx.message('register.confirm_info', extension_type.name))
         CLI::UI::Prompt.confirm(@ctx.message('register.confirm_question', app.title))
       end
 
@@ -54,10 +52,10 @@ module Extension
         Tasks::CreateExtension.call(
           context: @ctx,
           api_key: app.api_key,
-          type: @project.extension_type.identifier,
-          title: @project.title,
+          type: extension_type.identifier,
+          title: project.title,
           config: {},
-          extension_context: @project.extension_type.extension_context(@ctx)
+          extension_context: extension_type.extension_context(@ctx)
         )
       end
 
@@ -67,7 +65,7 @@ module Extension
           api_key: app.api_key,
           api_secret: app.secret,
           registration_id: registration.id,
-          title: @project.title
+          title: project.title
         )
       end
     end

--- a/lib/project_types/extension/commands/serve.rb
+++ b/lib/project_types/extension/commands/serve.rb
@@ -2,7 +2,7 @@
 
 module Extension
   module Commands
-    class Serve < ShopifyCli::Command
+    class Serve < ExtensionCommand
 
       YARN_SERVE_COMMAND = %w(yarn server)
       NPM_SERVE_COMMAND = %w(npm run-script server)

--- a/lib/project_types/extension/commands/tunnel.rb
+++ b/lib/project_types/extension/commands/tunnel.rb
@@ -3,7 +3,7 @@ require 'shopify_cli'
 
 module Extension
   module Commands
-    class Tunnel < ShopifyCli::Command
+    class Tunnel < ExtensionCommand
       options do |parser, flags|
         parser.on('--port=PORT') { |port| flags[:port] = port }
       end

--- a/lib/project_types/extension/extension_project.rb
+++ b/lib/project_types/extension/extension_project.rb
@@ -45,8 +45,8 @@ module Extension
       get_extra_field(ExtensionProjectKeys::TITLE_KEY)
     end
 
-    def extension_type
-      @extension_type ||= Models::Type.load_type(config[ExtensionProjectKeys::EXTENSION_TYPE_KEY])
+    def extension_type_identifier
+      config[ExtensionProjectKeys::EXTENSION_TYPE_KEY]
     end
 
     def registration_id?

--- a/lib/project_types/extension/messages/messages.rb
+++ b/lib/project_types/extension/messages/messages.rb
@@ -52,6 +52,9 @@ module Extension
           script_prepare_error: 'An error occurred while attempting to prepare your script.',
         },
       },
+      errors: {
+        unknown_type: 'Unknown extension type %s'
+      }
     }
 
     TYPES = {

--- a/test/project_types/extension/commands/extension_command_test.rb
+++ b/test/project_types/extension/commands/extension_command_test.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+require 'test_helper'
+require 'project_types/extension/extension_test_helpers'
+
+module Extension
+  module Commands
+    class ExtensionCommandTest < MiniTest::Test
+      include TestHelpers::FakeUI
+      include ExtensionTestHelpers::Messages
+      include ExtensionTestHelpers::TempProjectSetup
+
+      def setup
+        super
+        ShopifyCli::ProjectType.load_type(:extension)
+        @command = ExtensionCommand.new
+      end
+
+      def test_project_returns_the_current_extension_project
+        setup_temp_project
+
+        assert_equal @project, @command.project
+      end
+
+      def test_project_memoizes_the_current_extension_project
+        setup_temp_project
+        ExtensionProject.expects(:current).returns(@project).once
+
+        @command.project
+        @command.project
+      end
+
+      def test_extension_type_aborts_if_the_type_is_unknown
+        unknown_type = 'unknown_type'
+        setup_temp_project(type_identifier: unknown_type)
+
+        io = capture_io_and_assert_raises(ShopifyCli::Abort) { @command.extension_type }
+
+        assert_message_output(io: io, expected_content: [
+          @context.message('errors.unknown_type', unknown_type)
+        ])
+      end
+
+      def test_extension_type_returns_the_extension_type_instance_if_it_exists
+        setup_temp_project
+
+        assert_equal @test_extension_type, @command.extension_type
+      end
+
+      def test_extension_type_memoizes_the_extension_type
+        setup_temp_project
+        Models::Type.expects(:load_type).returns(@test_extension_type).once
+
+        @command.extension_type
+        @command.extension_type
+      end
+    end
+  end
+end

--- a/test/project_types/extension/commands/push_test.rb
+++ b/test/project_types/extension/commands/push_test.rb
@@ -60,8 +60,8 @@ module Extension
             context: @context,
             api_key: @api_key,
             registration_id: @registration_id,
-            config: @type.config(@context),
-            extension_context: @type.extension_context(@context)
+            config: @test_extension_type.config(@context),
+            extension_context: @test_extension_type.extension_context(@context)
           )
           .returns(@version)
           .once

--- a/test/project_types/extension/extension_project_test.rb
+++ b/test/project_types/extension/extension_project_test.rb
@@ -15,7 +15,7 @@ module Extension
 
       assert File.exists?('.shopify-cli.yml')
       assert_equal :extension, ShopifyCli::Project.current_project_type
-      assert_equal @test_extension_type, ExtensionProject.current.extension_type
+      assert_equal @test_extension_type.identifier, ExtensionProject.current.extension_type_identifier
     end
 
     def test_write_env_file_creates_env_file
@@ -80,11 +80,10 @@ module Extension
       assert_nil ExtensionProject.current.title
     end
 
-    def test_extension_type_returns_the_set_type_as_a_type_instance
+    def test_extension_type_returns_the_set_type_identifier
       setup_temp_project
 
-      assert_kind_of Models::Type, @project.extension_type
-      assert_equal @type.identifier, @project.extension_type.identifier
+      assert_equal @type, @project.extension_type_identifier
     end
 
     def test_detects_if_registration_id_is_missing_or_invalid

--- a/test/project_types/extension/extension_test_helpers/fake_extension_project.rb
+++ b/test/project_types/extension/extension_test_helpers/fake_extension_project.rb
@@ -14,7 +14,7 @@ module Extension
 
       def config
         {
-          ExtensionProjectKeys::EXTENSION_TYPE_KEY => type.identifier
+          ExtensionProjectKeys::EXTENSION_TYPE_KEY => type
         }
       end
 

--- a/test/project_types/extension/extension_test_helpers/temp_project_setup.rb
+++ b/test/project_types/extension/extension_test_helpers/temp_project_setup.rb
@@ -10,14 +10,14 @@ module Extension
         api_key: 'TEST_KEY',
         api_secret: 'TEST_SECRET',
         title: 'Test',
-        type: @test_extension_type,
+        type_identifier: @test_extension_type.identifier,
         registration_id: 55)
 
         @context = TestHelpers::FakeContext.new(root: '/fake/root')
         @api_key = api_key
         @api_secret = api_secret
         @title = title
-        @type = type
+        @type = type_identifier
         @registration_id = registration_id
 
         @project = FakeExtensionProject.new(

--- a/test/project_types/extension/messages/message_loading_test.rb
+++ b/test/project_types/extension/messages/message_loading_test.rb
@@ -57,7 +57,7 @@ module Extension
         setup_temp_project
         ShopifyCli::Project.expects(:has_current?).returns(true).once
         ShopifyCli::Project.stubs(:current).returns(@project).once
-        Messages::MessageLoading.expects(:messages_for_type).with(@type.identifier).once
+        Messages::MessageLoading.expects(:messages_for_type).with(@type).once
 
         Messages::MessageLoading.load_current_type_messages
       end
@@ -68,17 +68,17 @@ module Extension
 
       def test_messages_for_type_returns_nil_if_the_type_key_does_not_exist
         setup_temp_project
-        Messages::TYPES.expects(:has_key?).with(@type.identifier.downcase.to_sym).returns(false).once
+        Messages::TYPES.expects(:has_key?).with(@type.downcase.to_sym).returns(false).once
 
-        assert_nil Messages::MessageLoading.messages_for_type(@type.identifier)
+        assert_nil Messages::MessageLoading.messages_for_type(@type)
       end
 
       def test_messages_for_type_returns_type_messages_if_they_exist
         setup_temp_project
-        Messages::TYPES.expects(:has_key?).with(@type.identifier.downcase.to_sym).returns(true).once
-        Messages::TYPES.expects(:[]).with(@type.identifier.downcase.to_sym).returns(@fake_overrides).once
+        Messages::TYPES.expects(:has_key?).with(@type.downcase.to_sym).returns(true).once
+        Messages::TYPES.expects(:[]).with(@type.downcase.to_sym).returns(@fake_overrides).once
 
-        assert_equal @fake_overrides, Messages::MessageLoading.messages_for_type(@type.identifier)
+        assert_equal @fake_overrides, Messages::MessageLoading.messages_for_type(@type)
       end
     end
   end


### PR DESCRIPTION
### WHY are these changes introduced?
Closes: https://github.com/Shopify/app-extension-libs/issues/601

Previously if there was an unknown `type` in the `shopify-cli.yml` file we would have a full stack trace failure. This cleans up where we load the `type` and has a cleaner error for when the `type` is unknown.

### WHAT is this pull request doing?
- Adds `ExtensionCommand` that is responsible for loading `project` and the `type`. This gives us a common point to handle loading and loading errors.
- Updated `ExtensionProject` to no longer be responsible for loading the type and instead it only knows about the identifier. This better splits our concerns.
- Bunch of renames from `type` to `type_identifier` where we now us the identifier.
- Updated all command (except `Create`) to extend `ExtensionCommand`.
  - `Create` was skipped since it is a `Subcommand` not a `Command` and doesn't know about `type`
