### PR TITLE
Updating UX messages

### DIFF
--- a/lib/project_types/extension/messages/message_loading.rb
+++ b/lib/project_types/extension/messages/message_loading.rb
@@ -8,7 +8,7 @@ module Extension
         return Messages::MESSAGES if type_specific_messages.nil?
 
         if type_specific_messages.key?(:overrides)
-          Messages::MESSAGES.merge(type_specific_messages[:overrides])
+          deep_merge(Messages::MESSAGES, type_specific_messages[:overrides])
         else
           Messages::MESSAGES
         end
@@ -26,6 +26,13 @@ module Extension
         return unless Messages::TYPES.has_key?(type_identifier_symbol)
 
         TYPES[type_identifier_symbol]
+      end
+
+      private
+
+      def self.deep_merge(first, second)
+        merger = proc { |key, v1, v2| Hash === v1 && Hash === v2 ? v1.merge(v2, &merger) : v2 }
+        first.merge(second, &merger)
       end
     end
   end

--- a/lib/project_types/extension/messages/messages.rb
+++ b/lib/project_types/extension/messages/messages.rb
@@ -26,7 +26,7 @@ module Extension
         no_apps: '{{x}} You don’t have any apps.',
         learn_about_apps: '{{*}} Learn more about building apps at <https://shopify.dev/concepts/apps>, or try creating a new app using {{shopify create app.}}',
         invalid_api_key: 'The API key %s does not match any of your apps.',
-        confirm_info: 'You can only create one %s extension per app, which can’t be undone.',
+        confirm_info: 'This will create a new extension registration for %s, which can’t be undone.',
         confirm_question: 'Would you like to register this extension with {{green:%s}}? (y/n)',
         confirm_abort: 'Extension was not created.',
         success: '{{v}} Registered {{green:%s}} with {{green:%s}}.',
@@ -67,6 +67,11 @@ module Extension
       subscription_management: {
         name: 'Subscription Management',
         tagline: '(limit 1 per app)',
+        overrides: {
+          register: {
+            confirm_info: 'You can only create one %s extension per app, which can’t be undone.',
+          }
+        }
       },
       checkout_post_purchase: {
         name: 'Checkout Post Purchase',

--- a/test/project_types/extension/messages/message_loading_test.rb
+++ b/test/project_types/extension/messages/message_loading_test.rb
@@ -47,6 +47,13 @@ module Extension
         assert_equal @fake_overrides[:build][:frame_title], loaded_messages[:build][:frame_title]
       end
 
+      def test_load_does_a_deep_merge_and_retains_nested_non_overridden_messages
+        Messages::MessageLoading.expects(:load_current_type_messages).returns(@fake_override_messages).once
+
+        loaded_messages = Messages::MessageLoading.load
+        assert_equal Messages::MESSAGES[:build][:build_failure_message], loaded_messages[:build][:build_failure_message]
+      end
+
       def test_load_current_type_messages_returns_nil_if_there_is_no_current_project
         ShopifyCli::Project.expects(:has_current?).returns(false).once
 


### PR DESCRIPTION
### WHY are these changes introduced?
Paired with @amanbis and @iainmcampbell to take a quick look at some override messages.

### WHAT is this pull request doing?
- Needed to build in basic `deep_merge` functionality since we don't have ActiveSupport
- Added a test to ensure we aren't losing non-overridden messages in nested hashes