### PR TITLE
include port option in tunnel help text

### DIFF
--- a/lib/project_types/extension/commands/tunnel.rb
+++ b/lib/project_types/extension/commands/tunnel.rb
@@ -42,6 +42,8 @@ module Extension
 
             {{cyan:start}}: Starts an ngrok tunnel, will print the URL for an existing tunnel if already running.
               Usage: {{command:%1$s tunnel start}}
+              Options:
+              {{command:--port=PORT}} Forward the ngrok subdomain to local port PORT. Defaults to #{DEFAULT_PORT}.
 
             {{cyan:stop}}: Stops the ngrok tunnel.
               Usage: {{command:%1$s tunnel stop}}


### PR DESCRIPTION
### WHY are these changes introduced?

closes https://github.com/Shopify/app-extension-libs/issues/652


### WHAT is this pull request doing?

include `--port` flag in extended help text for tunnel




Tophatting:

EXTENSIONS
![image](https://user-images.githubusercontent.com/3375286/83922182-e389ca00-a74d-11ea-9248-6c8b1f2ca8b6.png)



build
![image](https://user-images.githubusercontent.com/3375286/83922370-32cffa80-a74e-11ea-833c-300fd99aac5a.png)

