### PR TITLE
Update copy displayed when successfully pushing extension

### DIFF
--- a/lib/project_types/extension/messages/messages.rb
+++ b/lib/project_types/extension/messages/messages.rb
@@ -35,7 +35,7 @@ module Extension
       push: {
         frame_title: 'Pushing your extension to Shopify',
         waiting_text: 'Pushing code to Shopify...',
-        success_confirmation: '{{v}} Pushed %s to a draft at %s.',
+        success_confirmation: '{{v}} Pushed %s to a draft on %s.',
         success_info: '{{*}} Visit <extension URL> to version and publish your extension.',
       },
       serve: {


### PR DESCRIPTION
### WHY are these changes introduced?

- we decided that with the time format we chose, this copy made more sense.
- see the comments here: https://github.com/Shopify/shopify-app-cli-extensions/pull/34#discussion_r427519740

### WHAT is this pull request doing?
- just updates the targeted copy

![Screen Shot 2020-06-05 at 5 50 51 PM](https://user-images.githubusercontent.com/4079241/83925420-1f745d80-a755-11ea-9236-fbebf98222d8.png)

