### PR TITLE
Adding status to tunnel command

### DIFF
--- a/lib/project_types/extension/cli.rb
+++ b/lib/project_types/extension/cli.rb
@@ -42,6 +42,7 @@ module Extension
   module Features
     autoload :Argo, Project.project_filepath('features/argo')
     autoload :ArgoDependencies, Project.project_filepath('features/argo_dependencies')
+    autoload :TunnelUrl, Project.project_filepath('features/tunnel_url')
   end
 
   module Models

--- a/lib/project_types/extension/features/tunnel_url.rb
+++ b/lib/project_types/extension/features/tunnel_url.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+require 'base64'
+
+module Extension
+  module Features
+    module TunnelUrl
+      NGROK_TUNNELS_URI = URI.parse('http://localhost:4040/api/tunnels')
+      TUNNELS_FIELD = 'tunnels'
+      PUBLIC_URL_FIELD = 'public_url'
+
+      def self.fetch
+        begin
+          response = Net::HTTP.get_response(NGROK_TUNNELS_URI)
+          json = JSON.parse(response.body)
+          return json.dig(TUNNELS_FIELD, 0, PUBLIC_URL_FIELD)
+        rescue
+          return nil
+        end
+      end
+    end
+  end
+end

--- a/lib/project_types/extension/messages/messages.rb
+++ b/lib/project_types/extension/messages/messages.rb
@@ -44,7 +44,30 @@ module Extension
       },
       tunnel: {
         missing_token: '{{x}} {{red:auth requires a token argument}}. Find it on your ngrok dashboard: {{underline:https://dashboard.ngrok.com/auth/your-authtoken}}.',
-        invalid_port: '%s is not a valid port.'
+        invalid_port: '%s is not a valid port.',
+        no_tunnel_running: 'No tunnel running.',
+        tunnel_running_at: 'Tunnel running at: {{underline:%s}}',
+        help: <<~HELP,
+          Start or stop an http tunnel to your local development extension using ngrok.
+            Usage: {{command:%s tunnel [ auth | start | stop | status ]}}
+        HELP
+        extended_help: <<~HELP,
+          {{bold:Subcommands:}}
+
+            {{cyan:auth}}: Writes an ngrok auth token to ~/.ngrok2/ngrok.yml to connect with an ngrok account. Visit https://dashboard.ngrok.com/signup to sign up.
+              Usage: {{command:%1$s tunnel auth <token>}}
+
+            {{cyan:start}}: Starts an ngrok tunnel, will print the URL for an existing tunnel if already running.
+              Usage: {{command:%1$s tunnel start}}
+              Options:
+              {{command:--port=PORT}} Forward the ngrok subdomain to local port PORT. Defaults to %2$s.
+
+            {{cyan:stop}}: Stops the ngrok tunnel.
+              Usage: {{command:%1$s tunnel stop}}
+
+            {{cyan:status}}: Output the current status of the ngrok tunnel.
+              Usage: {{command:%1$s tunnel status}}
+        HELP
       },
       features: {
         argo: {

--- a/test/project_types/extension/commands/tunnel_test.rb
+++ b/test/project_types/extension/commands/tunnel_test.rb
@@ -67,6 +67,23 @@ module Extension
         capture_io { run_tunnel(Tunnel::STOP_SUBCOMMAND) }
       end
 
+      def test_status_outputs_no_tunnel_running_if_tunnel_url_returns_nil
+        Features::TunnelUrl.expects(:fetch).returns(nil).once
+
+        io = capture_io { run_tunnel(Tunnel::STATUS_SUBCOMMAND) }
+
+        assert_message_output(io: io, expected_content: @context.message('tunnel.no_tunnel_running'))
+      end
+
+      def test_status_outputs_the_running_tunnel_url_if_returned_by_tunnel_url
+        fake_url = 'http://12345.ngrok.io'
+        Features::TunnelUrl.expects(:fetch).returns(fake_url).once
+
+        io = capture_io { run_tunnel(Tunnel::STATUS_SUBCOMMAND) }
+
+        assert_message_output(io: io, expected_content: @context.message('tunnel.tunnel_running_at', fake_url))
+      end
+
       private
 
       def run_tunnel(*args)

--- a/test/project_types/extension/features/tunnel_url_test.rb
+++ b/test/project_types/extension/features/tunnel_url_test.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+require 'test_helper'
+require 'project_types/extension/extension_test_helpers'
+
+module Extension
+  module Features
+    class TunnelUrlTest < MiniTest::Test
+      include TestHelpers::FakeUI
+
+      def setup
+        super
+        ShopifyCli::ProjectType.load_type(:extension)
+      end
+
+      def test_fetch_returns_the_first_ngrok_url_if_it_exists
+        fake_tunnel_uri = 'http://7b121913fab9.ngrok.io'
+        fake_tunnel_response = {
+          "tunnels": [
+            {
+              "name": "command_line (http)",
+              "uri": "/api/tunnels/command_line%20%28http%29",
+              "public_url": fake_tunnel_uri,
+              "proto": "http",
+              "config": {"addr": "http://localhost:39351", "inspect": true},
+              "metrics": {
+                "conns": {"count": 0, "gauge": 0, "rate1": 0, "rate5": 0, "rate15": 0, "p50": 0, "p90": 0, "p95": 0, "p99": 0},
+                "http": {"count": 0, "rate1": 0, "rate5": 0, "rate15": 0, "p50": 0, "p90": 0, "p95": 0, "p99": 0}
+              }
+            },
+            {
+              "name": "command_line",
+              "uri": "/api/tunnels/command_line",
+              "public_url": fake_tunnel_uri,
+              "proto": "https",
+              "config": {"addr": "http://localhost:39351", "inspect": true},
+              "metrics": {
+                "conns": {"count": 0, "gauge": 0, "rate1": 0, "rate5": 0, "rate15": 0, "p50": 0, "p90": 0, "p95": 0, "p99": 0},
+                "http": {"count": 0, "rate1": 0, "rate5": 0, "rate15": 0, "p50": 0, "p90": 0, "p95": 0, "p99": 0}
+              }
+            }
+          ],
+          "uri": "/api/tunnels"
+        }
+
+        mock_ngrok_tunnels_http_call(response_body: JSON.dump(fake_tunnel_response))
+
+        fetched_tunnel_uri = TunnelUrl.fetch
+        assert_equal fake_tunnel_uri, fetched_tunnel_uri
+      end
+
+      def test_fetch_returns_nil_and_does_not_raise_if_the_response_cannot_be_parsed_as_json
+        invalid_json_response = '<html><head></head><body><p>Error</p></html>'
+
+        mock_ngrok_tunnels_http_call(response_body: invalid_json_response)
+
+        assert_nothing_raised do
+          assert_nil TunnelUrl.fetch
+        end
+      end
+
+      def test_fetch_returns_nil_and_does_not_raise_if_the_response_has_no_tunnels
+        fake_tunnel_response = {
+          "tunnels": [ ],
+          "uri": "/api/tunnels"
+        }
+
+        mock_ngrok_tunnels_http_call(response_body: JSON.dump(fake_tunnel_response))
+
+        assert_nothing_raised do
+          assert_nil TunnelUrl.fetch
+        end
+      end
+
+      private
+
+      def mock_ngrok_tunnels_http_call(response_body:)
+        Net::HTTP
+          .expects(:get_response)
+          .with(TunnelUrl::NGROK_TUNNELS_URI)
+          .returns(mock(body: response_body))
+          .once
+      end
+    end
+  end
+end


### PR DESCRIPTION
### WHY are these changes introduced?
Part of: https://github.com/Shopify/app-extension-libs/issues/707

Currently, we don't have a way to know the current running tunnel URL. The status sub-command will add this ability to the Tunnel command.
This is Step 1 of 2 for being able to construct `ngrok` URLs for users when serving extensions locally.

### WHAT is this pull request doing?
- Adds the `TunnelUrl` feature (This is temporary and needs to be added to core CLI)
- Adds the `status` subcommand to the `Tunnel` command
- Updated the help messages because they were not formatting correctly

### Test Run
![Screen Shot 2020-06-12 at 1 07 20 PM](https://user-images.githubusercontent.com/42751082/84528687-213aa580-acae-11ea-8016-5975aa4ed3d3.png)
