### PR TITLE
Fixing newline character

### DIFF
--- a/lib/project_types/extension/messages/messages.rb
+++ b/lib/project_types/extension/messages/messages.rb
@@ -10,7 +10,7 @@ module Extension
         ask_type: 'What type of extension are you creating?',
         invalid_type: 'Extension type is invalid.',
         setup_project_frame_title: 'Initializing Project',
-        ready_to_start: '{{*}} You’re ready to start building {{green:%s}}!\nA new folder was generated at {{green:./%s}}. Navigate there, then run {{command:shopify serve}} to start a local server.',
+        ready_to_start: "{{*}} You’re ready to start building {{green:%s}}!\nA new folder was generated at {{green:./%s}}. Navigate there, then run {{command:shopify serve}} to start a local server.",
         learn_more: '{{*}} Register this extension with one of your apps by running {{command:shopify register}}.',
       },
       build: {


### PR DESCRIPTION
### What are you trying to accomplish?
The newline character is printed as /n instead of actually putting a new line. It also causes the text to wrap strangely
![84404809-4f988200-abd5-11ea-82fb-327b7ff74798](https://user-images.githubusercontent.com/65421598/84536214-5994b080-acbb-11ea-9db3-848dfa8f288f.png)


### What approach did you choose and why?

Used double quotes as they support newline character.

### What should reviewers focus on?

is there any better way using single quotes?


### The impact of these changes

<img width="1209" alt="Screen Shot 2020-06-12 at 3 55 45 PM (2)" src="https://user-images.githubusercontent.com/65421598/84541547-a1203a00-acc5-11ea-8d29-ee12b4d5e050.png">


## Before you deploy

- [] I [tophatted](https://development.shopify.io/engineering/developing_at_Shopify/write-code/tophatting) or tested this change.

1. Shopify load-dev on the extensions fork of the cli
2. create a subscription extension with whatever options
3. read the final success output


- [x] This PR is [safe to rollback](https://development.shopify.io/engineering/developersToolbox/ship/safe_to_merge#Signs_your_PR_is_safe_to_rollback).

Output of Dev Test

<img width="896" alt="Screen Shot 2020-06-12 at 4 02 56 PM" src="https://user-images.githubusercontent.com/65421598/84542022-931ee900-acc6-11ea-958a-c909fa1fba54.png">
