### PR TITLE
Display validation errors on push

### DIFF
--- a/lib/project_types/extension/commands/push.rb
+++ b/lib/project_types/extension/commands/push.rb
@@ -12,7 +12,7 @@ module Extension
 
         CLI::UI::Frame.open(@ctx.message('push.frame_title')) do
           updated_draft_version = update_draft
-          show_confirmation_message(updated_draft_version.last_user_interaction_at, updated_draft_version.location)
+          show_message(updated_draft_version)
         end
       end
 
@@ -25,9 +25,23 @@ module Extension
 
       private
 
-      def show_confirmation_message(confirmed_at, location)
-        @ctx.puts(@ctx.message('push.success_confirmation', project.title, format_time(confirmed_at)))
-        @ctx.puts(@ctx.message('push.success_info', location))
+      def show_message(draft)
+        draft.validation_errors.empty? ? output_success_messages(draft) : output_validation_errors(draft)
+      end
+
+      def output_success_messages(draft)
+        @ctx.puts(@ctx.message('push.success_confirmation', project.title, format_time(draft.last_user_interaction_at)))
+        @ctx.puts(@ctx.message('push.success_info', draft.location))
+      end
+
+      def output_validation_errors(draft)
+        @ctx.puts(@ctx.message('push.pushed_with_errors', format_time(draft.last_user_interaction_at)))
+
+        draft.validation_errors.each do |error|
+          @ctx.puts('{{x}} %s: %s' % [error.field.last, error.message])
+        end
+
+        @ctx.puts(@ctx.message('push.push_with_errors_info'))
       end
 
       def format_time(time)

--- a/lib/project_types/extension/messages/messages.rb
+++ b/lib/project_types/extension/messages/messages.rb
@@ -35,7 +35,9 @@ module Extension
       push: {
         frame_title: 'Pushing your extension to Shopify',
         waiting_text: 'Pushing code to Shopify...',
-        success_confirmation: '{{v}} Pushed %s to a draft at %s.',
+        pushed_with_errors: '{{x}} Code pushed to Shopify with errors on %s.',
+        push_with_errors_info: '{{*}} Fix these errors and run {{command:shopify push}} to revalidate your extension.',
+        success_confirmation: '{{v}} Pushed {{green:%s}} to a draft on %s.',
         success_info: '{{*}} Visit %s to version and publish your extension.',
       },
       serve: {


### PR DESCRIPTION
### WHY are these changes introduced?
Fixes: https://github.com/Shopify/app-extension-libs/issues/302
Built on: https://github.com/Shopify/shopify-app-cli-extensions/pull/25

The second step to complete the `ValidationErrors` task. This task checks for validation errors in the `push` command. If no validation errors occurred the standard success messaging is output. If any validation errors are present they are output the user with different messaging.

### WHAT is this pull request doing?
- Adds `validation_errors` output to `push`
- Minor UX changes that came up with pairing with @amanbis 

### Test Run
![Screen Shot 2020-06-12 at 4 53 54 PM](https://user-images.githubusercontent.com/42751082/84545449-51de0780-accd-11ea-988e-e0dec76c9ae9.png)
