### PR TITLE
Stop Argo NPM dependency check from checking minor if major is suffic…

### DIFF
--- a/lib/project_types/extension/features/argo_dependencies.rb
+++ b/lib/project_types/extension/features/argo_dependencies.rb
@@ -4,7 +4,7 @@ module Extension
   module Features
     class ArgoDependencies
       def self.node_installed(min_major:, min_minor: nil)
-        Proc.new do |context|
+        -> (context) do
           out, status = CLI::Kit::System.capture2(*%w(node -v))
           context.abort(context.message('features.argo.dependencies.node.node_not_installed')) unless status.success?
 
@@ -15,6 +15,8 @@ module Extension
           unless min_major.nil? || parsed_version[:major].to_i >= min_major
             context.abort(context.message('features.argo.dependencies.node.version_too_low', version, min_version))
           end
+
+          return if parsed_version[:major].to_i > min_major
 
           unless min_minor.nil? || parsed_version[:minor].to_i >= min_minor
             context.abort(context.message('features.argo.dependencies.node.version_too_low', version, min_version))

--- a/test/project_types/extension/features/argo_dependencies_test.rb
+++ b/test/project_types/extension/features/argo_dependencies_test.rb
@@ -54,7 +54,7 @@ module Extension
         ])
       end
 
-      def test_if_node_exists_but_minor_version_is_under_the_minimum_abort_with_message
+      def test_if_major_version_is_the_minimum_version_abort_with_message_if_minor_version_is_under_the_minimum_version
         mock_node_version('v10.11.12')
 
         io = capture_io_and_assert_raises(ShopifyCli::Abort) do
@@ -64,6 +64,14 @@ module Extension
         assert_message_output(io: io, expected_content: [
           @context.message('features.argo.dependencies.node.version_too_low', 'v10.11.12', 'v10.12.x')
         ])
+      end
+
+      def test_if_major_version_is_the_above_the_minimum_version_do_not_check_minor_version
+        mock_node_version('v13.7.0')
+
+        assert_nothing_raised do
+          ArgoDependencies.node_installed(min_major: 10, min_minor: 13).call(@context)
+        end
       end
 
       private


### PR DESCRIPTION
### WHY are these changes introduced?
Fixes https://github.com/Shopify/app-extension-libs/issues/695

If the `major` version number is sufficient (eg 12 when 10 is needed) there is no need to then check the `minor` dependency number.

### WHAT is this pull request doing?
- Exit the npm check lambda if the major version is greater than the minimum major

### Fix Test Runs
#### Failing after the test was added
![Screen Shot 2020-06-15 at 9 46 22 AM](https://user-images.githubusercontent.com/42751082/84665871-5b928580-aeee-11ea-83dc-bbf6c1c7ac02.png)

#### Passing after fix
![Screen Shot 2020-06-15 at 9 46 37 AM](https://user-images.githubusercontent.com/42751082/84665902-63eac080-aeee-11ea-92b8-c80282bc7732.png)

### Test Run
![Screen Shot 2020-06-15 at 9 56 10 AM](https://user-images.githubusercontent.com/42751082/84665955-7664fa00-aeee-11ea-8b85-628408cd5f55.png)


