### PR TITLE
Adding cleanup and messaging if template initialization fails

### DIFF
--- a/lib/project_types/extension/cli.rb
+++ b/lib/project_types/extension/cli.rb
@@ -47,6 +47,7 @@ module Extension
 
   module Features
     autoload :Argo, Project.project_filepath('features/argo')
+    autoload :ArgoSetup, Project.project_filepath('features/argo_setup')
     autoload :ArgoDependencies, Project.project_filepath('features/argo_dependencies')
     autoload :TunnelUrl, Project.project_filepath('features/tunnel_url')
   end

--- a/lib/project_types/extension/commands/create.rb
+++ b/lib/project_types/extension/commands/create.rb
@@ -10,13 +10,15 @@ module Extension
 
       def call(args, _)
         with_create_form(args) do |form|
-          form.type.create(form.directory_name, @ctx)
+          if form.type.create(form.directory_name, @ctx)
+            ExtensionProject.write_cli_file(context: @ctx, type: form.type.identifier)
+            ExtensionProject.write_env_file(context: @ctx, title: form.name)
 
-          ExtensionProject.write_cli_file(context: @ctx, type: form.type.identifier)
-          ExtensionProject.write_env_file(context: @ctx, title: form.name)
-
-          @ctx.puts(@ctx.message('create.ready_to_start', form.name, form.directory_name))
-          @ctx.puts(@ctx.message('create.learn_more', form.type.name))
+            @ctx.puts(@ctx.message('create.ready_to_start', form.name, form.directory_name))
+            @ctx.puts(@ctx.message('create.learn_more', form.type.name))
+          else
+            @ctx.puts(@ctx.message('create.try_again'))
+          end
         end
       end
 

--- a/lib/project_types/extension/features/argo.rb
+++ b/lib/project_types/extension/features/argo.rb
@@ -10,39 +10,25 @@ module Extension
       GIT_CHECKOUT_TEMPLATE = 'https://github.com/Shopify/argo-checkout-template.git'.freeze
       SCRIPT_PATH = %w(build main.js).freeze
 
-      GIT_DIRECTORY = '.git'.freeze
-      SCRIPTS_DIRECTORY = 'scripts'.freeze
-
-      YARN_INITIALIZE_COMMAND = %w(generate).freeze
-      NPM_INITIALIZE_COMMAND = %w(run generate --).freeze
-      INITIALIZE_TYPE_PARAMETER = '--type=%s'.freeze
-
       class << self
         def admin
-          @admin ||= Argo.new(git_template: GIT_ADMIN_TEMPLATE)
+          @admin ||= Argo.new(setup: ArgoSetup.new(git_template: GIT_ADMIN_TEMPLATE))
         end
 
         def checkout
-          @checkout ||= Argo.new(git_template: GIT_CHECKOUT_TEMPLATE, dependency_checks: [
-            ArgoDependencies.node_installed(min_major: 10, min_minor: 13)
-          ])
+          @checkout ||= Argo.new(
+            setup: ArgoSetup.new(
+              git_template: GIT_CHECKOUT_TEMPLATE,
+              dependency_checks: [ArgoDependencies.node_installed(min_major: 10, min_minor: 13)]
+            )
+          )
         end
       end
 
-      property! :git_template, accepts: String
-      property! :dependency_checks, default: []
+      property! :setup, accepts: Features::ArgoSetup
 
       def create(directory_name, identifier, context)
-        check_dependencies(context)
-        clone_template(directory_name, context)
-        initialize_project(identifier, context)
-        cleanup(context)
-      end
-
-      def check_dependencies(context)
-        dependency_checks.each do |dependency_check|
-          dependency_check.call(context)
-        end
+        setup.call(directory_name, identifier, context)
       end
 
       def config(context)
@@ -55,32 +41,6 @@ module Extension
           }
         rescue Exception
           context.abort(context.message('features.argo.script_prepare_error'))
-        end
-      end
-
-      def clone_template(directory_name, context)
-        ShopifyCli::Git.clone(git_template, directory_name, ctx: context)
-        context.root = File.join(context.root, directory_name)
-      end
-
-      def initialize_project(identifier, context)
-        system = ShopifyCli::JsSystem.new(ctx: context)
-        ShopifyCli::JsDeps.new(ctx: context, system: system).install
-
-        CLI::UI::Frame.open(context.message('create.setup_project_frame_title')) do
-          system.call(
-            yarn: YARN_INITIALIZE_COMMAND + [INITIALIZE_TYPE_PARAMETER % identifier],
-            npm: NPM_INITIALIZE_COMMAND + [INITIALIZE_TYPE_PARAMETER % identifier]
-          )
-        end
-      end
-
-      def cleanup(context)
-        begin
-          context.rm_r(GIT_DIRECTORY)
-          context.rm_r(SCRIPTS_DIRECTORY)
-        rescue Errno::ENOENT => e
-          context.debug(e)
         end
       end
     end

--- a/lib/project_types/extension/features/argo_setup.rb
+++ b/lib/project_types/extension/features/argo_setup.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+require 'base64'
+
+module Extension
+  module Features
+    class ArgoSetup
+      include SmartProperties
+
+      GIT_DIRECTORY = '.git'.freeze
+      SCRIPTS_DIRECTORY = 'scripts'.freeze
+
+      YARN_INITIALIZE_COMMAND = %w(generate).freeze
+      NPM_INITIALIZE_COMMAND = %w(run generate --).freeze
+      INITIALIZE_TYPE_PARAMETER = '--type=%s'.freeze
+
+      property! :git_template, accepts: String
+      property! :dependency_checks, default: []
+
+      attr_accessor :success
+
+      def call(directory_name, identifier, context)
+        @success = true
+
+        check_dependencies(context)
+        clone_template(directory_name, context)
+        initialize_project(identifier, context)
+        cleanup(context, directory_name)
+
+        @success
+      end
+
+      def check_dependencies(context)
+        dependency_checks.each do |dependency_check|
+          dependency_check.call(context)
+        end
+      end
+
+      def clone_template(directory_name, context)
+        ShopifyCli::Git.clone(git_template, directory_name, ctx: context)
+        context.root = File.join(context.root, directory_name)
+      end
+
+      def initialize_project(identifier, context)
+        system = ShopifyCli::JsSystem.new(ctx: context)
+        ShopifyCli::JsDeps.new(ctx: context, system: system).install
+
+        frame_title = context.message('create.setup_project_frame_title')
+        failure_message = context.message('features.argo.initialization_error')
+
+        CLI::UI::Frame.open(frame_title, failure_text: failure_message) do
+          @success = system.call(
+            yarn: YARN_INITIALIZE_COMMAND + [INITIALIZE_TYPE_PARAMETER % identifier],
+            npm: NPM_INITIALIZE_COMMAND + [INITIALIZE_TYPE_PARAMETER % identifier]
+          )
+        end
+      end
+
+      def cleanup(context, directory_name)
+        @success ? cleanup_template(context) : cleanup_on_failure(context, directory_name)
+      end
+
+      def cleanup_template(context)
+        begin
+          context.rm_r(GIT_DIRECTORY)
+          context.rm_r(SCRIPTS_DIRECTORY)
+        rescue Errno::ENOENT => e
+          context.debug(e)
+        end
+      end
+
+      def cleanup_on_failure(context, directory_name)
+        begin
+          FileUtils.rm_r(directory_name) if Dir.exists?(directory_name)
+        rescue Errno::ENOENT => e
+          context.debug(e)
+        end
+      end
+    end
+  end
+end

--- a/lib/project_types/extension/messages/messages.rb
+++ b/lib/project_types/extension/messages/messages.rb
@@ -12,6 +12,7 @@ module Extension
         setup_project_frame_title: 'Initializing project',
         ready_to_start: "{{*}} You’re ready to start building {{green:%s}}!\nA new folder was generated at {{green:./%s}}. Navigate there, then run {{command:shopify serve}} to start a local server.",
         learn_more: '{{*}} Register this extension with one of your apps by running {{command:shopify register}}.',
+        try_again: '{{*}} Fix the errors and run {{command:shopify create extension}} again.',
       },
       build: {
         frame_title: 'Building extension with: %s...',
@@ -75,6 +76,7 @@ module Extension
         argo: {
           missing_file_error: 'Could not find built extension file.',
           script_prepare_error: 'An error occurred while attempting to prepare your script.',
+          initialization_error: '{{x}} There was an error while initializing the project.',
           dependencies: {
             node: {
               node_not_installed: 'Node must be installed to create this extension.',

--- a/test/project_types/extension/commands/create_test.rb
+++ b/test/project_types/extension/commands/create_test.rb
@@ -10,37 +10,58 @@ module Extension
       include ExtensionTestHelpers::Messages
       include ExtensionTestHelpers::Stubs::GetOrganizations
 
+      def setup
+        super
+        @name = "My Ext"
+        @directory_name = 'my_ext'
+      end
+
       def test_prints_help
         io = capture_io { run_cmd('create extension --help') }
         assert_message_output(io: io, expected_content: [Extension::Commands::Create.help])
       end
 
       def test_runs_type_create_and_writes_project_files
-        name = "My Ext"
-        directory_name = 'my_ext'
-
-        @test_extension_type.expects(:create).with(directory_name, @context).once
+        @test_extension_type.expects(:create).with(@directory_name, @context).returns(true).once
         ExtensionProject.expects(:write_cli_file).with(context: @context, type: @test_extension_type.identifier).once
-        ExtensionProject.expects(:write_env_file).with(context: @context, title: name).once
+        ExtensionProject.expects(:write_env_file).with(context: @context, title: @name).once
 
         io = capture_io do
-          Commands::Create.ctx = @context
-          arguments = %W(extension --name=#{name} --type=#{@test_extension_type.identifier})
-          Commands::Create.call(arguments, 'create', 'create')
+          run_create(%W(extension --name=#{@name} --type=#{@test_extension_type.identifier}))
         end
 
         assert_message_output(io: io, expected_content: [
-          @context.message('create.ready_to_start', name, directory_name),
+          @context.message('create.ready_to_start', @name, @directory_name),
           @context.message('create.learn_more', @test_extension_type.name)
         ])
       end
 
+      def test_does_not_create_project_files_and_outputs_try_again_message_if_type_create_failed
+        @test_extension_type.expects(:create).with(@directory_name, @context).returns(false).once
+        ExtensionProject.expects(:write_cli_file).never
+        ExtensionProject.expects(:write_env_file).never
+
+        io = capture_io do
+          run_create(%W(extension --name=#{@name} --type=#{@test_extension_type.identifier}))
+        end
+
+        assert_message_output(io: io, expected_content: @context.message('create.try_again'))
+      end
+
       def test_help_does_not_load_extension_project_type
         io = capture_io do
-          run_cmd('create --help')
+          run_create(%w(create --help))
         end
+
         output = io.join
         refute_match('extension', output)
+      end
+
+      private
+
+      def run_create(arguments)
+        Commands::Create.ctx = @context
+        Commands::Create.call(arguments, 'create', 'create')
       end
     end
   end

--- a/test/project_types/extension/features/argo_setup_test.rb
+++ b/test/project_types/extension/features/argo_setup_test.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+require 'test_helper'
+require 'project_types/extension/extension_test_helpers'
+require 'pathname'
+
+module Extension
+  module Features
+    class ArgoSetupTest < MiniTest::Test
+      include TestHelpers::FakeUI
+
+      def setup
+        super
+        ShopifyCli::ProjectType.load_type(:extension)
+
+        @git_template = 'https://www.github.com/fake_template.git'
+        @initializer = ArgoSetup.new(git_template: @git_template)
+        @identifier = 'FAKE_ARGO_TYPE'
+        @directory = 'fake_directory'
+      end
+
+      def test_call_clones_repo_then_initializes_project_then_cleans_up
+        @initializer.expects(:check_dependencies).with(@context).once
+        @initializer.expects(:clone_template).with(@directory, @context).once
+        @initializer.expects(:initialize_project).with(@identifier, @context).once
+        @initializer.expects(:cleanup).with(@context, @directory).once
+
+        @initializer.call(@directory, @identifier, @context)
+      end
+
+      def test_check_dependencies_loops_through_the_provided_dependencies
+        execution_mock = Minitest::Mock.new
+        execution_mock.expect(:executed, nil)
+
+        test_proc = Proc.new do |context|
+          execution_mock.executed
+          assert_equal @context, context
+        end
+
+        ArgoSetup.new(git_template: @git_template, dependency_checks: [test_proc]).check_dependencies(@context)
+        execution_mock.verify
+      end
+
+      def test_clone_template_clones_argo_template_git_repo_into_directory_and_updates_context_root
+        ShopifyCli::Git.expects(:clone).with(@git_template, @directory, ctx: @context).once
+
+        @initializer.clone_template(@directory, @context)
+
+        assert_equal @directory, Pathname(@context.root).each_filename.to_a.last
+      end
+
+      def test_initialize_project_installs_js_deps_and_initializes_the_project_setting_success_true_if_successful
+        type_parameter = [ArgoSetup::INITIALIZE_TYPE_PARAMETER % @identifier]
+        expected_npm_command = ArgoSetup::NPM_INITIALIZE_COMMAND + type_parameter
+        expected_yarn_command = ArgoSetup::YARN_INITIALIZE_COMMAND + type_parameter
+
+        ShopifyCli::JsDeps.any_instance.expects(:install).once
+        ShopifyCli::JsSystem.any_instance
+          .expects(:call)
+          .with(yarn: expected_yarn_command, npm: expected_npm_command)
+          .returns(true)
+          .once
+
+        @initializer.initialize_project(@identifier, @context)
+        assert @initializer.success
+      end
+
+      def test_initialize_project_sets_success_to_false_if_initialize_command_fails
+        type_parameter = [ArgoSetup::INITIALIZE_TYPE_PARAMETER % @identifier]
+        expected_npm_command = ArgoSetup::NPM_INITIALIZE_COMMAND + type_parameter
+        expected_yarn_command = ArgoSetup::YARN_INITIALIZE_COMMAND + type_parameter
+
+        ShopifyCli::JsDeps.any_instance.expects(:install).once
+        ShopifyCli::JsSystem.any_instance
+          .expects(:call)
+          .with(yarn: expected_yarn_command, npm: expected_npm_command)
+          .returns(false)
+          .once
+
+        @initializer.initialize_project(@identifier, @context)
+        refute @initializer.success
+      end
+
+      def test_cleanup_runs_cleanup_template_if_success_is_true
+        @initializer.success = true
+        @initializer.expects(:cleanup_template).with(@context).once
+        @initializer.expects(:cleanup_on_failure).never
+
+        @initializer.cleanup(@context, @directory)
+      end
+
+      def test_cleanup_runs_cleanup_on_failure_if_success_is_false
+        @initializer.success = false
+        @initializer.expects(:cleanup_template).never
+        @initializer.expects(:cleanup_on_failure).with(@context, @directory).once
+
+        @initializer.cleanup(@context, @directory)
+      end
+
+      def test_cleanup_template_removes_git_and_script_directories
+        @context.expects(:rm_r).with(ArgoSetup::GIT_DIRECTORY).once
+        @context.expects(:rm_r).with(ArgoSetup::SCRIPTS_DIRECTORY).once
+
+        @initializer.cleanup_template(@context)
+      end
+
+      def test_cleanup_on_failure_removes_extension_directory_if_it_has_been_created
+        Dir.expects(:exists?).with(@directory).returns(true).once
+        FileUtils.expects(:rm_r).with(@directory).once
+
+        @initializer.cleanup_on_failure(@context, @directory)
+      end
+
+      def test_cleanup_on_failure_does_nothing_if_failure_occurred_before_extension_directory_was_created
+        Dir.expects(:exists?).with(@directory).returns(false).once
+        FileUtils.expects(:rm_r).with(@directory).never
+
+        @initializer.cleanup_on_failure(@context, @directory)
+      end
+    end
+  end
+end

--- a/test/project_types/extension/features/argo_test.rb
+++ b/test/project_types/extension/features/argo_test.rb
@@ -15,46 +15,9 @@ module Extension
         ShopifyCli::ProjectType.load_type(:extension)
 
         @git_template = 'https://www.github.com/fake_template.git'
-        @argo = Argo.new(git_template: @git_template)
+        @argo = Argo.new(setup: Features::ArgoSetup.new(git_template: @git_template))
         @identifier = 'FAKE_ARGO_TYPE'
         @directory = 'fake_directory'
-      end
-
-      def test_create_clones_repo_then_initializes_project_then_cleans_up
-        @argo.expects(:check_dependencies).with(@context).once
-        @argo.expects(:clone_template).with(@directory, @context).once
-        @argo.expects(:initialize_project).with(@identifier, @context).once
-        @argo.expects(:cleanup).with(@context).once
-
-        @argo.create(@directory, @identifier, @context)
-      end
-
-      def test_clone_template_clones_argo_template_git_repo_into_directory_and_updates_context_root
-        ShopifyCli::Git.expects(:clone).with(@git_template, @directory, ctx: @context).once
-
-        @argo.clone_template(@directory, @context)
-
-        assert_equal @directory, Pathname(@context.root).each_filename.to_a.last
-      end
-
-      def test_initialize_project_installs_js_dependencies_and_requests_js_system_to_generate
-        expected_npm_command = Argo::NPM_INITIALIZE_COMMAND + [Argo::INITIALIZE_TYPE_PARAMETER % @identifier]
-        expected_yarn_command = Argo::YARN_INITIALIZE_COMMAND + [Argo::INITIALIZE_TYPE_PARAMETER % @identifier]
-
-        ShopifyCli::JsDeps.any_instance.expects(:install).once
-        ShopifyCli::JsSystem.any_instance
-          .expects(:call)
-          .with(yarn: expected_yarn_command, npm: expected_npm_command)
-          .once
-
-        @argo.initialize_project(@identifier, @context)
-      end
-
-      def test_cleanup_removes_git_and_script_directories
-        @context.expects(:rm_r).with(Argo::GIT_DIRECTORY).once
-        @context.expects(:rm_r).with(Argo::SCRIPTS_DIRECTORY).once
-
-        @argo.cleanup(@context)
       end
 
       def test_config_aborts_with_error_if_script_file_doesnt_exist
@@ -90,29 +53,16 @@ module Extension
         end
       end
 
-      def test_check_dependencies_loops_through_the_provided_dependencies
-        execution_mock = Minitest::Mock.new
-        execution_mock.expect(:executed, nil)
-
-        test_proc = Proc.new do |context|
-          execution_mock.executed
-          assert_equal @context, context
-        end
-
-        Argo.new(git_template: @git_template, dependency_checks: [test_proc]).check_dependencies(@context)
-        execution_mock.verify
-      end
-
       def test_admin_method_returns_an_argo_extension_with_the_subscription_management_template
         git_admin_template = 'https://github.com/Shopify/shopify-app-extension-template.git'.freeze
         argo = Argo.admin
-        assert_equal(argo.git_template, git_admin_template)
+        assert_equal(argo.setup.git_template, git_admin_template)
       end
 
       def test_checkout_method_returns_an_argo_extension_with_the_checkout_post_purchase_template
         git_checkout_template = 'https://github.com/Shopify/argo-checkout-template.git'.freeze
         argo = Argo.checkout
-        assert_equal(argo.git_template, git_checkout_template)
+        assert_equal(argo.setup.git_template, git_checkout_template)
       end
     end
   end


### PR DESCRIPTION
### WHY are these changes introduced?
Part of: https://github.com/Shopify/app-extension-libs/issues/719

Previously we were not checking the status of the template initialization. This lead to weird messaging and leftover folders when the template failed. This PR aims to do the following:

- Improved messaging when template initialization fails
- Cleanup created folders when initialization fails

### WHAT is this pull request doing?
- Split out `ArgoSetup` which deals with creating an Argo extension
- Added a `success` tracker to the `ArgoSetup` class to know the current state of initialization
- Updated the `initialize_project` method to update `success` based on its success
- Updated `cleanup` to cleanup differently if we are in a failure state.
- Updated the `create` command to handle the case of a failure state from `type.create`

Note: This fixes the general use cases of handling errors that occur on the CLI. The issue is that the issue steps given do not cause the system command to report an error. I haven't found a way for us to detect that specific error on the CLI. I think the template has to be updated to throw that as an actual error somehow.

### Experience
#### Previous Experience
![previous_experience](https://user-images.githubusercontent.com/42751082/84693801-0f5b3b80-af16-11ea-83a9-c0c462b19287.gif)

#### New Experience
![new_experience](https://user-images.githubusercontent.com/42751082/84693817-17b37680-af16-11ea-9ce2-ea88d4024e18.gif)

### Test Run
![Screen Shot 2020-06-15 at 2 31 29 PM](https://user-images.githubusercontent.com/42751082/84693836-20a44800-af16-11ea-8d95-3acde12d5eac.png)


