### PR TITLE
Updated abort text on register

### DIFF
--- a/lib/project_types/extension/commands/register.rb
+++ b/lib/project_types/extension/commands/register.rb
@@ -13,7 +13,7 @@ module Extension
 
           with_register_form(args) do |form|
             should_continue = confirm_registration(form.app)
-            registration = should_continue ? register_extension(form.app) : @ctx.abort(@ctx.message('register.confirm_abort'))
+            registration = should_continue ? register_extension(form.app) : abort_not_registered
 
             update_project_files(form.app, registration)
 
@@ -67,6 +67,11 @@ module Extension
           registration_id: registration.id,
           title: project.title
         )
+      end
+
+      def abort_not_registered
+        @ctx.puts(@ctx.message('register.confirm_abort'))
+        raise ShopifyCli::AbortSilent
       end
     end
   end

--- a/lib/project_types/extension/messages/messages.rb
+++ b/lib/project_types/extension/messages/messages.rb
@@ -28,7 +28,7 @@ module Extension
         invalid_api_key: 'The API key %s does not match any of your apps.',
         confirm_info: 'This will create a new extension registration for %s, which can’t be undone.',
         confirm_question: 'Would you like to register this extension with {{green:%s}}? (y/n)',
-        confirm_abort: 'Extension was not created.',
+        confirm_abort: 'Extension was not registered.',
         success: '{{v}} Registered {{green:%s}} with {{green:%s}}.',
         success_info: '{{*}} Run {{command:shopify push}} to push your extension to Shopify.',
       },

--- a/test/project_types/extension/commands/register_test.rb
+++ b/test/project_types/extension/commands/register_test.rb
@@ -44,7 +44,7 @@ module Extension
           .returns(false)
           .once
 
-        io = capture_io_and_assert_raises(ShopifyCli::Abort) { run_register_command }
+        io = capture_io_and_assert_raises(ShopifyCli::AbortSilent) { run_register_command }
 
         assert_message_output(io: io, expected_content: [
           @context.message('register.confirm_abort'),


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes: https://github.com/Shopify/app-extension-libs/issues/722

### WHAT is this pull request doing?

- Updated abort text on register and made it a silent abort

Local testing:
<img width="2558" alt="Screen Shot 2020-06-15 at 5 02 40 PM" src="https://user-images.githubusercontent.com/59700729/84706985-eba2f000-af2b-11ea-8991-5f5da349f96c.png">

Running tests:
<img width="2557" alt="Screen Shot 2020-06-15 at 5 02 15 PM" src="https://user-images.githubusercontent.com/59700729/84707014-f5c4ee80-af2b-11ea-9d9f-b1776161c3da.png">