### PR TITLE
[cli] bump node minor version to 16 for checkout argo extension

### DIFF
--- a/lib/project_types/extension/features/argo.rb
+++ b/lib/project_types/extension/features/argo.rb
@@ -19,7 +19,7 @@ module Extension
           @checkout ||= Argo.new(
             setup: ArgoSetup.new(
               git_template: GIT_CHECKOUT_TEMPLATE,
-              dependency_checks: [ArgoDependencies.node_installed(min_major: 10, min_minor: 13)]
+              dependency_checks: [ArgoDependencies.node_installed(min_major: 10, min_minor: 16)]
             )
           )
         end


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/app-extension-libs/issues/702

Getting exception when using node version < 10.16.0 for creating argo checkout extension. Please see following screenshot.
<img width="1672" alt="84520578-c56a1f80-aca1-11ea-982b-9aa7b6d1b3cd" src="https://user-images.githubusercontent.com/65421598/84709116-b13b5200-af2f-11ea-99fe-981423d6af6f.png">


### WHAT is this pull request doing?

Bump the minor version to 16 from 13 for checkout Argo extension.
 
### Test

1. **dev test is successful** Please see following screenshot.

<img width="1200" alt="Screen Shot 2020-06-15 at 3 59 16 PM" src="https://user-images.githubusercontent.com/65421598/84709631-87365f80-af30-11ea-8c19-d6ab471b59e5.png">

2. **When using node version < 10.16.0, getting correct error.**

<img width="1036" alt="Screen Shot 2020-06-15 at 3 53 49 PM" src="https://user-images.githubusercontent.com/65421598/84709710-b2b94a00-af30-11ea-9576-ecc7510bd751.png">

3. **Using node version >= 10.16.0, able to create checkout extension** (This test includes bumping the node version >= 10.16.0 in argo-checkout-template as well, a separate PR has been opened for that. Link: https://github.com/Shopify/argo-checkout-template/pull/12).

<img width="1218" alt="Screen Shot 2020-06-15 at 6 00 34 PM" src="https://user-images.githubusercontent.com/65421598/84710646-a209d380-af32-11ea-8e14-aadcd28dfa03.png">

<img width="656" alt="Screen Shot 2020-06-15 at 6 01 06 PM" src="https://user-images.githubusercontent.com/65421598/84710662-a8984b00-af32-11ea-8711-f157f2eca18c.png">


## Before you deploy

- [] I [tophatted](https://development.shopify.io/engineering/developing_at_Shopify/write-code/tophatting) or tested this change.
Case 1. Use node version >= 10.16.0, should be able to create checkout extension
Case 2. Use node version < 10.16.0, should get proper error message.


- [x] This PR is [safe to rollback](https://development.shopify.io/engineering/developersToolbox/ship/safe_to_merge#Signs_your_PR_is_safe_to_rollback).



