### PR TITLE
Updating the initializing project frame title

### DIFF
--- a/lib/project_types/extension/messages/messages.rb
+++ b/lib/project_types/extension/messages/messages.rb
@@ -9,7 +9,7 @@ module Extension
         invalid_name: 'Extension name must be under %s characters',
         ask_type: 'What type of extension are you creating?',
         invalid_type: 'Extension type is invalid.',
-        setup_project_frame_title: 'Initializing Project',
+        setup_project_frame_title: 'Initializing project',
         ready_to_start: "{{*}} You’re ready to start building {{green:%s}}!\nA new folder was generated at {{green:./%s}}. Navigate there, then run {{command:shopify serve}} to start a local server.",
         learn_more: '{{*}} Register this extension with one of your apps by running {{command:shopify register}}.',
       },


### PR DESCRIPTION
### WHY are these changes introduced?
Fixes https://github.com/Shopify/app-extension-libs/issues/729

Update to the frame title as requested by UX.

### WHAT is this pull request doing?
- Updating the string in the messages hash

### Demo
#### Previous title
![Screen Shot 2020-06-16 at 8 37 22 AM](https://user-images.githubusercontent.com/42751082/84775326-12edd180-afad-11ea-9d01-2bb2224dd579.png)

#### New title
![Screen Shot 2020-06-16 at 8 39 06 AM](https://user-images.githubusercontent.com/42751082/84775342-18e3b280-afad-11ea-9870-9918b67652fb.png)

### Test Run
![Screen Shot 2020-06-16 at 8 41 20 AM](https://user-images.githubusercontent.com/42751082/84775396-2bf68280-afad-11ea-989d-b657c4e90f64.png)
