### PR TITLE
Updating the Argo admin template name

### DIFF
--- a/lib/project_types/extension/features/argo.rb
+++ b/lib/project_types/extension/features/argo.rb
@@ -6,7 +6,7 @@ module Extension
     class Argo
       include SmartProperties
 
-      GIT_ADMIN_TEMPLATE = 'https://github.com/Shopify/shopify-app-extension-template.git'.freeze
+      GIT_ADMIN_TEMPLATE = 'https://github.com/Shopify/argo-admin-template.git'.freeze
       GIT_CHECKOUT_TEMPLATE = 'https://github.com/Shopify/argo-checkout-template.git'.freeze
       SCRIPT_PATH = %w(build main.js).freeze
 

--- a/test/project_types/extension/features/argo_test.rb
+++ b/test/project_types/extension/features/argo_test.rb
@@ -54,7 +54,7 @@ module Extension
       end
 
       def test_admin_method_returns_an_argo_extension_with_the_subscription_management_template
-        git_admin_template = 'https://github.com/Shopify/shopify-app-extension-template.git'.freeze
+        git_admin_template = 'https://github.com/Shopify/argo-admin-template.git'.freeze
         argo = Argo.admin
         assert_equal(argo.setup.git_template, git_admin_template)
       end


### PR DESCRIPTION
### WHY are these changes introduced?
Part of: https://github.com/Shopify/app-extension-libs/issues/654 to align the two templates (Admin/Checkout) of Argo we are updating the name of the admin template from `shopify-app-extension-template` to `argo-admin-template`.

**Note: PR must go in AFTER the rename of the repository.**

### WHAT is this pull request doing?
Renaming the admin template repository location.

### Manual Testing
![Screen Shot 2020-06-17 at 12 32 14 PM](https://user-images.githubusercontent.com/42751082/84924504-99321280-b096-11ea-9281-5109a7eeb4fa.png)


### Test Run
<img width="1265" alt="Screen Shot 2020-06-17 at 8 38 32 AM" src="https://user-images.githubusercontent.com/42751082/84899314-7ee83c80-b076-11ea-8235-86935db0865e.png">
