### PR TITLE
Fix flakiness in registration tests

### DIFF
--- a/test/project_types/extension/models/registration_test.rb
+++ b/test/project_types/extension/models/registration_test.rb
@@ -4,6 +4,11 @@ require 'test_helper'
 module Extension
   module Models
     class RegistrationTest < MiniTest::Test
+      def setup
+        super
+        ShopifyCli::ProjectType.load_type(:extension)
+      end
+
       def test_valid_title_returns_true_for_valid_title
         assert Models::Registration.valid_title?('A title')
       end


### PR DESCRIPTION
### WHY are these changes introduced?
Before running any tests you need to load the extension type so all of the `autoload` statements in the `cli.rb` are present.

The Registration test was skipping this step so if it was the first test suite to run it would fail.

### WHAT is this pull request doing?
- Load extension type in the setup of the registration tests

### Isolated Test Runs
#### Before fix
![Screen Shot 2020-06-17 at 9 06 51 AM](https://user-images.githubusercontent.com/42751082/84901758-ea7fd900-b079-11ea-82c3-7d1aaeae7587.png)

#### After Fix
![Screen Shot 2020-06-17 at 9 07 26 AM](https://user-images.githubusercontent.com/42751082/84901815-fc617c00-b079-11ea-9e53-3fa6d15656f0.png)

### Test Run
![Screen Shot 2020-06-17 at 9 07 57 AM](https://user-images.githubusercontent.com/42751082/84901878-0daa8880-b07a-11ea-85ce-6159c3ecf16f.png)
