### PR TITLE
Adding the concept of setup steps to error fast

### DIFF
--- a/lib/project_types/extension/cli.rb
+++ b/lib/project_types/extension/cli.rb
@@ -48,6 +48,8 @@ module Extension
   module Features
     autoload :Argo, Project.project_filepath('features/argo')
     autoload :ArgoSetup, Project.project_filepath('features/argo_setup')
+    autoload :ArgoSetupStep, Project.project_filepath('features/argo_setup_step')
+    autoload :ArgoSetupSteps, Project.project_filepath('features/argo_setup_steps')
     autoload :ArgoDependencies, Project.project_filepath('features/argo_dependencies')
     autoload :TunnelUrl, Project.project_filepath('features/tunnel_url')
   end

--- a/lib/project_types/extension/features/argo_setup_step.rb
+++ b/lib/project_types/extension/features/argo_setup_step.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Extension
+  module Features
+    class ArgoSetupStep
+      include SmartProperties
+
+      property! :step
+      property! :can_fail, accepts: [true, false], reader: :can_fail?
+
+      def call(context, identifier, directory_name, js_system)
+        step_result = step.call(context, identifier, directory_name, js_system)
+        can_fail? ? step_result : true
+      rescue ShopifyCli::Abort => e
+        context.puts(e.message)
+        false
+      rescue Exception => e
+        context.puts("{{x}} #{e.message}")
+        false
+      end
+
+      def self.default(&block)
+        ArgoSetupStep.new(step: block, can_fail: true)
+      end
+
+      def self.always_successful(&block)
+        ArgoSetupStep.new(step: block, can_fail: false)
+      end
+    end
+  end
+end

--- a/lib/project_types/extension/features/argo_setup_steps.rb
+++ b/lib/project_types/extension/features/argo_setup_steps.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module Extension
+  module Features
+    module ArgoSetupSteps
+      YARN_INITIALIZE_COMMAND = %w(generate).freeze
+      NPM_INITIALIZE_COMMAND = %w(run generate --).freeze
+      INITIALIZE_TYPE_PARAMETER = '--type=%s'.freeze
+
+      def self.check_dependencies(dependency_checks)
+        ArgoSetupStep.always_successful do |context, _identifier, _directory_name, _js_system|
+          dependency_checks.each do |dependency_check|
+            dependency_check.call(context)
+          end
+        end
+      end
+
+      def self.clone_template(git_template)
+        ArgoSetupStep.default do |context, _identifier, directory_name, _js_system|
+          begin
+            ShopifyCli::Git.clone(git_template, directory_name, ctx: context)
+            context.root = File.join(context.root, directory_name)
+          rescue Exception
+            context.puts('{{x}} Unable to clone the repository.')
+          end
+        end
+      end
+
+      def self.install_dependencies
+        ArgoSetupStep.default do |context, _identifier, _directory_name, js_system|
+          ShopifyCli::JsDeps.new(ctx: context, system: js_system).install
+        end
+      end
+
+      def self.initialize_project
+        ArgoSetupStep.default do |context, identifier, _directory_name, js_system|
+          frame_title = context.message('create.setup_project_frame_title')
+          failure_message = context.message('features.argo.initialization_error')
+
+          result = true
+          CLI::UI::Frame.open(frame_title, failure_text: failure_message) do
+            result = js_system.call(
+              yarn: YARN_INITIALIZE_COMMAND + [INITIALIZE_TYPE_PARAMETER % identifier],
+              npm: NPM_INITIALIZE_COMMAND + [INITIALIZE_TYPE_PARAMETER % identifier]
+            )
+          end
+
+          result
+        end
+      end
+    end
+  end
+end

--- a/lib/project_types/extension/messages/messages.rb
+++ b/lib/project_types/extension/messages/messages.rb
@@ -19,6 +19,7 @@ module Extension
         {{*}} Once you're ready to version and publish your extension,
         run {{command:shopify register}} to register this extension with one of your apps.
         MESSAGE
+        try_again: '{{*}} Fix the errors and run {{command:shopify create extension}} again.',
       },
       build: {
         frame_title: 'Building extension with: %s...',

--- a/test/project_types/extension/features/argo_setup_step_test.rb
+++ b/test/project_types/extension/features/argo_setup_step_test.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+require 'test_helper'
+require 'project_types/extension/extension_test_helpers'
+
+module Extension
+  module Features
+    class ArgoSetupStepsTest < MiniTest::Test
+      include TestHelpers::FakeUI
+      include ExtensionTestHelpers::Messages
+
+      def setup
+        super
+        ShopifyCli::ProjectType.load_type(:extension)
+
+        @identifier = 'FAKE_ARGO_TYPE'
+        @directory = 'fake_directory'
+        @system = ShopifyCli::JsSystem.new(ctx: @context)
+      end
+
+      def test_always_successful_steps_return_true_no_matter_what_the_step_block_returns
+        assert call_step(ArgoSetupStep.always_successful { false })
+        assert call_step(ArgoSetupStep.always_successful { true })
+      end
+
+      def test_default_steps_return_what_the_step_block_returns
+        refute call_step(ArgoSetupStep.default { false })
+        assert call_step(ArgoSetupStep.default { true })
+      end
+
+      def test_all_step_types_catch_shopify_cli_abort_exceptions_and_output_their_message_and_return_false
+        always_successful_io = capture_io do
+          refute call_step(ArgoSetupStep.always_successful { raise ShopifyCli::Abort, 'always_successful error' })
+        end
+
+        default_io = capture_io do
+          refute call_step(ArgoSetupStep.default { raise ShopifyCli::Abort, 'default_io error' })
+        end
+
+        assert_message_output(io: always_successful_io, expected_content: 'always_successful error')
+        assert_message_output(io: default_io, expected_content: 'default_io error')
+      end
+
+      def test_all_step_types_catch_any_exceptions_and_output_their_message_and_return_false
+        always_successful_io = capture_io do
+          refute call_step(ArgoSetupStep.always_successful { raise 'always_successful error' })
+        end
+
+        default_io = capture_io do
+          refute call_step(ArgoSetupStep.default { raise 'default_io error' })
+        end
+
+        assert_message_output(io: always_successful_io, expected_content: '{{x}} always_successful error')
+        assert_message_output(io: default_io, expected_content: '{{x}} default_io error')
+      end
+
+      private
+
+      def call_step(step, context: @context, identifier: @identifier, directory_name: @directory, system: @system)
+        step.call(context, identifier, directory_name, system)
+      end
+    end
+  end
+end

--- a/test/project_types/extension/features/argo_setup_steps_test.rb
+++ b/test/project_types/extension/features/argo_setup_steps_test.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+require 'test_helper'
+require 'project_types/extension/extension_test_helpers'
+
+module Extension
+  module Features
+    class ArgoSetupStepsTest < MiniTest::Test
+      include TestHelpers::FakeUI
+
+      def setup
+        super
+        ShopifyCli::ProjectType.load_type(:extension)
+
+        @git_template = 'https://www.github.com/fake_template.git'
+        @identifier = 'FAKE_ARGO_TYPE'
+        @directory = 'fake_directory'
+        @system = ShopifyCli::JsSystem.new(ctx: @context)
+      end
+
+
+      def test_check_dependencies_loops_through_the_provided_dependencies
+        execution_mock = Minitest::Mock.new
+        execution_mock.expect(:executed, nil)
+
+        test_proc = Proc.new do |context|
+          execution_mock.executed
+          assert_equal @context, context
+        end
+
+        call_step(ArgoSetupSteps.check_dependencies([test_proc]))
+        execution_mock.verify
+      end
+
+      def test_clone_template_clones_argo_template_git_repo_into_directory_and_updates_context_root
+        ShopifyCli::Git.expects(:clone).with(@git_template, @directory, ctx: @context).once
+
+        call_step(ArgoSetupSteps.clone_template(@git_template))
+
+        assert_equal @directory, Pathname(@context.root).each_filename.to_a.last
+      end
+
+      def test_install_dependencies_calls_js_deps_to_install_dependencies_and_returns_the_install_result
+        ShopifyCli::JsDeps.any_instance.expects(:install).returns(true).once
+        assert call_step(ArgoSetupSteps.install_dependencies)
+
+        ShopifyCli::JsDeps.any_instance.expects(:install).returns(false).once
+        refute call_step(ArgoSetupSteps.install_dependencies)
+      end
+
+      def test_initialize_project_runs_the_initialize_command_with_js_system_and_returns_true_if_successful
+        type_parameter = [ArgoSetupSteps::INITIALIZE_TYPE_PARAMETER % @identifier]
+        expected_npm_command = ArgoSetupSteps::NPM_INITIALIZE_COMMAND + type_parameter
+        expected_yarn_command = ArgoSetupSteps::YARN_INITIALIZE_COMMAND + type_parameter
+
+        @system
+          .expects(:call)
+          .with(yarn: expected_yarn_command, npm: expected_npm_command)
+          .returns(true)
+          .once
+
+        assert call_step(ArgoSetupSteps.initialize_project)
+      end
+
+      def test_initialize_project_runs_the_initialize_command_with_js_system_and_returns_false_when_fails
+        type_parameter = [ArgoSetupSteps::INITIALIZE_TYPE_PARAMETER % @identifier]
+        expected_npm_command = ArgoSetupSteps::NPM_INITIALIZE_COMMAND + type_parameter
+        expected_yarn_command = ArgoSetupSteps::YARN_INITIALIZE_COMMAND + type_parameter
+
+        @system
+          .expects(:call)
+          .with(yarn: expected_yarn_command, npm: expected_npm_command)
+          .returns(false)
+          .once
+
+        refute call_step(ArgoSetupSteps.initialize_project)
+      end
+
+      private
+
+      def call_step(step, context: @context, identifier: @identifier, directory_name: @directory, system: @system)
+        step.call(context, identifier, directory_name, system)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### WHY are these changes introduced?
Closes: https://github.com/Shopify/app-extension-libs/issues/719

Currently, we have multiple steps that are required to setup an extension locally but we do not handle failure in each step well. This PR formalizes the concept of a `SetupStep` which can then be combined together to perform a full step. If any step along the way fails subsequent steps will not be run and the attempted setup process will be cleaned up.

### WHAT is this pull request doing?
- Create the `ArgoSetupStep` concept
- Moved previous steps to `ArgoSetupSteps`
- Update `ArgoSetup` to have a list of `ArgoSetupSteps`
- Update `ArgoSetup` to run steps until failure.
- Adds back message lost here: https://github.com/Shopify/shopify-app-cli-extensions/commit/021223f92b089f1a36eb699516bb42d6e0ce087a#diff-607a5d13759cc671093feffa874182d6

### Demos
#### Success case
![success](https://user-images.githubusercontent.com/42751082/84950468-f5a82880-b0bc-11ea-8902-09b8e5be94bb.gif)

#### Failure cases
Example of a step raising an exception:
![2020-06-17 17 03 49](https://user-images.githubusercontent.com/42751082/84950619-2e480200-b0bd-11ea-9a44-4086393d2684.gif)

**All following failures were caused by just returning false from the step. UX is not the purpose but to show each step can cancel out and cleanup**

Dependency check failure:
![dependency_failure](https://user-images.githubusercontent.com/42751082/84950571-1d978c00-b0bd-11ea-8448-f91d69abc4d3.gif)

Clone failure:
![clone_failure](https://user-images.githubusercontent.com/42751082/84950538-140e2400-b0bd-11ea-947b-d0d205a2b72f.gif)

Install Dependencies failure:
![install_dependencies_failure](https://user-images.githubusercontent.com/42751082/84950587-24260380-b0bd-11ea-97e7-fe46e325b2b2.gif)

Initialize Project failure:
![initialize_failure](https://user-images.githubusercontent.com/42751082/84950637-3607a680-b0bd-11ea-906b-7d63f7aaf45b.gif)

### Test Run
![passing_tests](https://user-images.githubusercontent.com/42751082/84950670-43249580-b0bd-11ea-881a-6dec084803fe.png)


