### PR TITLE
Fixing messaging on create success

### DIFF
--- a/lib/project_types/extension/commands/create.rb
+++ b/lib/project_types/extension/commands/create.rb
@@ -14,7 +14,7 @@ module Extension
             ExtensionProject.write_cli_file(context: @ctx, type: form.type.identifier)
             ExtensionProject.write_env_file(context: @ctx, title: form.name)
 
-            @ctx.puts(@ctx.message('create.ready_to_start', form.name, form.directory_name))
+            @ctx.puts(@ctx.message('create.ready_to_start', form.directory_name, form.name))
             @ctx.puts(@ctx.message('create.learn_more', form.type.name))
           else
             @ctx.puts(@ctx.message('create.try_again'))

--- a/test/project_types/extension/commands/create_test.rb
+++ b/test/project_types/extension/commands/create_test.rb
@@ -31,7 +31,7 @@ module Extension
         end
 
         assert_message_output(io: io, expected_content: [
-          @context.message('create.ready_to_start', @name, @directory_name),
+          @context.message('create.ready_to_start', @directory_name, @name),
           @context.message('create.learn_more', @test_extension_type.name)
         ])
       end


### PR DESCRIPTION
### WHY are these changes introduced?
While doing a quick test I saw that the `name` and `directory_name` were backwards on the output text for the `create` command.

### WHAT is this pull request doing?
- Fix the test to the proper output

### Manual Test
#### Before
![old](https://user-images.githubusercontent.com/42751082/84944313-8bd75100-b0b3-11ea-841e-0a4b19cba725.png)

#### After
![new](https://user-images.githubusercontent.com/42751082/84944325-9265c880-b0b3-11ea-9c9b-2d5b4a7bac54.png)

### Test Run
![passing_tests](https://user-images.githubusercontent.com/42751082/84944340-998cd680-b0b3-11ea-9830-aa4dd9329a53.png)

